### PR TITLE
Add revivals, failure traces, ready traces

### DIFF
--- a/Branching_Bisimilarity.thy
+++ b/Branching_Bisimilarity.thy
@@ -574,7 +574,7 @@ lemma sr_branching_bisimulation_stuttering_all:
     sr_branching_bisimulation_stuttering
   by metis
 
-theorem \<open>(p ~SRBB q) = (p \<preceq> (E \<infinity> \<infinity> \<infinity> \<infinity> \<infinity> \<infinity> \<infinity> \<infinity>) q)\<close>
+theorem \<open>(p ~SRBB q) = (p \<preceq> (E \<infinity> \<infinity> \<infinity> \<infinity> \<infinity> \<infinity> \<infinity> \<infinity> \<infinity>) q)\<close>
   using sr_branching_bisim_is_hmlsrbb \<O>_sup
   unfolding expr_preord_def by auto
 

--- a/Distinction_Implies_Winning_Budgets.thy
+++ b/Distinction_Implies_Winning_Budgets.thy
@@ -80,7 +80,7 @@ proof-
             Q \<noteq> {} \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q
             \<longrightarrow> attacker_wins (expr_pr_inner \<chi>) (Defender_Conj p Q))
         \<and> (\<forall>\<Psi>_I \<Psi> p Q Qr. \<chi> = StableConj \<Psi>_I \<Psi> \<longrightarrow>
-            Q \<noteq> {} \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p (Q \<union> Qr) \<longrightarrow> (\<forall>q \<in> Q \<union> Qr. stable_state q)
+            Q \<noteq> {} \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p (Q \<union> Qr) \<longrightarrow> stable_state p \<longrightarrow> (\<forall>q \<in> Q \<union> Qr. stable_state q)
             \<longrightarrow> attacker_wins (expr_pr_inner \<chi>) (Defender_Stable_Conj p Q Qr))
         \<and> (\<forall>\<Psi>_I \<Psi> \<alpha> \<phi> p Q p' Q_\<alpha>. \<chi> = BranchConj \<alpha> \<phi> \<Psi>_I \<Psi> \<longrightarrow>
             hml_srbb_inner.distinguishes_from \<chi> p Q \<longrightarrow> p \<mapsto>a \<alpha> p' \<longrightarrow> p' \<Turnstile>SRBB \<phi> \<longrightarrow>
@@ -89,8 +89,9 @@ proof-
       \<and>
         (\<forall>p q. hml_srbb_conj.distinguishes \<psi> p q
                \<longrightarrow> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Clause p q))
-        \<and> (\<forall>p q. hml_srbb_conj.distinguishes \<psi> p q
-               \<longrightarrow> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Stable_Clause p q))\<close>
+        \<and> (\<forall>p q e'. hml_srbb_conj.distinguishes \<psi> p q \<longrightarrow> stable_state p \<longrightarrow> stable_state q
+               \<longrightarrow> expr_pr_conjunct \<psi> \<le> e' \<longrightarrow> pos_conjuncts e' \<le> pos_conjuncts_sec e'
+               \<longrightarrow> attacker_wins e' (Attacker_Stable_Clause p q))\<close>
     \<comment> \<open>Likely, I should add another induction hypothesis to cater for conjuncts that distinguish from sets ... ?\<close>
   proof -
     fix \<phi> \<chi> \<psi>
@@ -102,8 +103,8 @@ proof-
         \<and> (\<forall>\<Psi>_I \<Psi> p Q. \<chi> = Conj \<Psi>_I \<Psi> \<longrightarrow>
             Q \<noteq> {} \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q
             \<longrightarrow> attacker_wins (expr_pr_inner \<chi>) (Defender_Conj p Q))
-        \<and> (\<forall>\<Psi>_I \<Psi> p Q Qr. \<chi> = StableConj \<Psi>_I \<Psi> \<longrightarrow>
-            Q \<noteq> {} \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p (Q \<union> Qr) \<longrightarrow> (\<forall>q \<in> Q \<union> Qr. stable_state q)
+        \<and> (\<forall>\<Psi>_I \<Psi> p Q Qr. \<chi> = StableConj \<Psi>_I \<Psi> \<longrightarrow> Q \<noteq> {} \<longrightarrow>
+                hml_srbb_inner.distinguishes_from \<chi> p (Q \<union> Qr) \<longrightarrow> stable_state p  \<longrightarrow> (\<forall>q \<in> Q \<union> Qr. stable_state q)
             \<longrightarrow> attacker_wins (expr_pr_inner \<chi>) (Defender_Stable_Conj p Q Qr))
         \<and> (\<forall>\<Psi>_I \<Psi> \<alpha> \<phi> p Q p' Q_\<alpha>. \<chi> = BranchConj \<alpha> \<phi> \<Psi>_I \<Psi> \<longrightarrow>
             hml_srbb_inner.distinguishes_from \<chi> p Q \<longrightarrow> p \<mapsto>a \<alpha> p' \<longrightarrow> p' \<Turnstile>SRBB \<phi> \<longrightarrow>
@@ -112,8 +113,9 @@ proof-
       \<and>
         (\<forall>p q. hml_srbb_conj.distinguishes \<psi> p q
                \<longrightarrow> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Clause p q))
-        \<and> (\<forall>p q. hml_srbb_conj.distinguishes \<psi> p q
-               \<longrightarrow> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Stable_Clause p q))\<close>
+        \<and> (\<forall>p q e'. hml_srbb_conj.distinguishes \<psi> p q \<longrightarrow> stable_state p \<longrightarrow> stable_state q
+               \<longrightarrow> expr_pr_conjunct \<psi> \<le> e' \<longrightarrow> pos_conjuncts e' \<le> pos_conjuncts_sec e'
+               \<longrightarrow> attacker_wins e' (Attacker_Stable_Clause p q))\<close>
     proof (induct rule: hml_srbb_hml_srbb_inner_hml_srbb_conjunct.induct[of _ _ _ \<phi> \<chi> \<psi>])
       case TT
       then show ?case
@@ -429,20 +431,21 @@ proof-
     next
       case (StableConj I \<psi>s)
       have main_case: \<open>\<forall>\<Psi>_I \<Psi> p Q Qr. Q \<noteq> {} \<longrightarrow>
-           hml_srbb_inner.distinguishes_from (StableConj I \<psi>s) p (Q \<union> Qr) \<longrightarrow>
+           hml_srbb_inner.distinguishes_from (StableConj I \<psi>s) p (Q \<union> Qr) \<longrightarrow> stable_state p \<longrightarrow>
            (\<forall>q\<in>Q \<union> Qr. stable_state q) \<longrightarrow> attacker_wins (expr_pr_inner (StableConj I \<psi>s)) (Defender_Stable_Conj p Q Qr)\<close>
       proof clarify
         fix p Q Qr
         assume case_assms:
           \<open>Q \<noteq> {}\<close>
           \<open>hml_srbb_inner.distinguishes_from (StableConj I \<psi>s) p (Q \<union> Qr)\<close>
+          \<open>stable_state p\<close>
           \<open>\<forall>q\<in>Q\<union>Qr. stable_state q\<close>
         hence distinctions: \<open>\<forall>q\<in>Q\<union>Qr. \<exists>i\<in>I. hml_srbb_conj.distinguishes (\<psi>s i) p q\<close>
           by simp
         hence inductive_wins: \<open>\<forall>q\<in>Q\<union>Qr. \<exists>i\<in>I. hml_srbb_conj.distinguishes (\<psi>s i) p q
             \<and> attacker_wins (expr_pr_conjunct (\<psi>s i)) (Attacker_Clause p q)
             \<and> attacker_wins (expr_pr_conjunct (\<psi>s i)) (Attacker_Stable_Clause p q)\<close>
-          using StableConj by blast
+          using StableConj case_assms(3,4) sorry (*by (meson rangeI)*)
         define \<psi>qs where
           \<open>\<psi>qs \<equiv> \<lambda>q. (SOME \<psi>. \<exists>i\<in>I. \<psi> = \<psi>s i \<and>  hml_srbb_conj.distinguishes \<psi> p q
             \<and> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Clause p q)
@@ -461,12 +464,13 @@ proof-
           (Sup (st_conj_depth  ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
           (Sup (imm_conj_depth  ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
           (Sup (pos_conjuncts   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))
-                \<union> pos_conjuncts_sec   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+                ))
           (Sup (pos_conjuncts_sec   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
           (Sup (neg_conjuncts ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
           (Sup ({1} \<union> neg_depth ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))\<close>
         from conjuncts_present have conj_prices: \<open>\<forall>q\<in>Q\<union>Qr. (expr_pr_conjunct (\<psi>qs q)) \<le> e'\<close> unfolding e'_def
           by (smt (z3) Sup_upper UnI1 UnI2 energy.sel image_insert insert_iff leq_components mk_disjoint_insert)
+(*\<union> pos_conjuncts_sec   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr))) *)
         hence clause_win: \<open>\<forall>q\<in>Q. attacker_wins e' (Attacker_Stable_Clause p q)\<close>
           using \<psi>qs_spec win_a_upwards_closure by blast
         have clause_win_revivals: \<open>attacker_wins e' (Attacker_Delayed p Qr)\<close>
@@ -522,9 +526,10 @@ proof-
             using subset_form
             apply (auto simp add: Sup_subset_mono image_mono sup.coboundedI2)
              defer
-            apply
+            by
                (smt (z3) SUP_cong Sup_le_iff Sup_upper sup_Q_I equal_sets(2) dual_order.trans
                 energy.sel(7) image_iff image_image mem_Collect_eq)
+(*
             proof -
               assume a1: "\<psi>qs ` (Q \<union> Qr) \<subseteq> \<psi>s ` I"
               obtain ee :: "enat \<Rightarrow> enat set \<Rightarrow> enat" where
@@ -545,7 +550,7 @@ proof-
                 using f6 by blast
               then show "Sup (pos_conjuncts ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>qs ` (Q \<union> Qr) \<union> pos_conjuncts_sec ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>qs ` (Q \<union> Qr)) \<le> Sup (pos_conjuncts ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>s ` I)"
                 using f4 by meson
-            qed
+            qed *)
           define e where \<open>e = E
             (modal_depth e')
             (br_conj_depth e')
@@ -553,12 +558,16 @@ proof-
             (1 + st_conj_depth e')
             (imm_conj_depth e')
             (pos_conjuncts e')
-            (pos_conjuncts_sec e')
+            (max (pos_conjuncts e') (pos_conjuncts_sec e'))
             (neg_conjuncts e')
             (sup 1 (neg_depth e'))\<close>
-          have \<open>e' = e - (E 0 0 0 1 0 0 0 0 0)\<close> unfolding e_def e'_def by auto
-          hence \<open>Some e' = (subtract_fn 0 0 0 1 0 0 0 0 0) e\<close>
-            by (metis e_def energy.sel energy_leq_cases i0_lb le_iff_add)
+          have e'_bound:
+              \<open>e' \<le> the (Option.bind (if \<not> E 0 0 0 1 0 0 0 0 0 \<le> e then None else Some (e - E 0 0 0 1 0 0 0 0 0)) min6_7)\<close>
+            unfolding e_def e'_def min_6_7_subtr_simp apply auto
+            using max_positive_conjunct_depth_dominates_secondary
+            by (smt (verit, del_insts) SUP_le_iff SUP_upper2 energy.sel(6) energy.sel(7) image_iff)
+          (* hence \<open>Some e' = (subtract_fn 0 0 0 1 0 0 0 0 0) e\<close>
+            by (metis e_def energy.sel energy_leq_cases i0_lb le_iff_add)*)
           have expr_lower: \<open>(E 0 0 0 1 0 0 0 0 0) \<le> expr_pr_inner (StableConj I \<psi>s)\<close>
             using case_assms(1) subset_form by force
           have eu'_comp: \<open>eu' = (expr_pr_inner (StableConj I \<psi>s)) - (E 0 0 0 1 0 0 0 0 0)\<close>
@@ -618,9 +627,9 @@ proof-
             proof cases
               case stable_answer
               then show ?thesis
-                using clause_win \<open>Some e' = (subtract_fn 0 0 0 1 0 0 0 0 0) e\<close>
+                using clause_win e'_bound
                 unfolding e_def
-                sledgehammer
+                using min_6_7_subtr_simp win_a_upwards_closure by auto
             next
               case stable_revival
               then show ?thesis using clause_win_revivals sorry
@@ -634,9 +643,10 @@ proof-
             unfolding e_def
             by (auto simp add: attacker_wins.Defense)
           moreover have \<open>e \<le> expr_pr_inner (StableConj I \<psi>s)\<close>
-            using \<open>e' \<le> eu'\<close> eu'_characterization \<open>Some e' = (subtract_fn 0 0 0 1 0 0 0 0 0) e\<close> expr_lower case_assms(1) subset_form
-            unfolding e_def eu'_comp minus_energy_def leq_components
-            by (metis \<open>e' = e - E 0 0 0 1 0 0 0 0 0\<close> \<open>e' \<le> eu'\<close> e_def energy_subtraction_inequallity eu'_comp leq_components option.discI)
+            using \<open>e' \<le> eu'\<close> eu'_characterization e'_bound expr_lower case_assms(1) subset_form
+            unfolding e_def eu'_comp minus_energy_def leq_components min_6_7_subtr_simp
+            sorry
+            (* by (metis \<open>e' \<le> eu'\<close> e_def energy_subtraction_inequallity eu'_comp leq_components option.discI) *)
          ultimately show \<open>attacker_wins (expr_pr_inner (StableConj I \<psi>s)) (Defender_Stable_Conj p Q Qr)\<close>
             using win_a_upwards_closure by blast
         next
@@ -647,105 +657,11 @@ proof-
 
           then show ?thesis sorry
         qed
-
-
-        have conjuncts_present: \<open>\<forall>q\<in>Q. expr_pr_conjunct (\<psi>qs q) \<in> expr_pr_conjunct ` (\<psi>qs ` Q)\<close>
-          using \<open>Q \<noteq> {}\<close> by blast
-        define e' where \<open>e' = E
-          (Sup (modal_depth   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
-          (Sup (br_conj_depth   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
-          (Sup (conj_depth ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
-          (Sup (st_conj_depth  ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
-          (Sup (imm_conj_depth  ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
-          (Sup (pos_conjuncts   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
-          (Sup (((\<lambda>\<psi>. case \<psi> of (Pos \<chi>) \<Rightarrow> modal_depth_srbb_inner \<chi> | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct \<psi>) \<circ> \<psi>qs)
-            ` ((Q\<union>Qr) - (revival_conjunct_index (Q\<union>Qr) \<psi>qs))))
-          (Sup (neg_conjuncts ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
-          (Sup ({1} \<union> neg_depth ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))\<close>
-        from conjuncts_present have \<open>\<forall>q\<in>Q\<union>Qr. (expr_pr_conjunct (\<psi>qs q)) \<le> e'\<close> unfolding e'_def
-          by (smt (z3) Sup_upper UnI2 energy.sel image_insert insert_iff leq_components mk_disjoint_insert)
-        with \<psi>qs_spec win_a_upwards_closure
-          have clause_win: \<open>\<forall>q\<in>Q. attacker_wins e' (Attacker_Stable_Clause p q)\<close> by blast
-        define eu' where \<open>eu' = E
-          (Sup (modal_depth   ` (expr_pr_conjunct ` (\<psi>s ` I))))
-          (Sup (br_conj_depth   ` (expr_pr_conjunct ` (\<psi>s ` I))))
-          (Sup (conj_depth ` (expr_pr_conjunct ` (\<psi>s ` I))))
-          (Sup (st_conj_depth  ` (expr_pr_conjunct ` (\<psi>s ` I))))
-          (Sup (imm_conj_depth  ` (expr_pr_conjunct ` (\<psi>s ` I))))
-          (Sup (pos_conjuncts   ` (expr_pr_conjunct ` (\<psi>s ` I))))
-          (Sup (((\<lambda>\<psi>. case \<psi> of (Pos \<chi>) \<Rightarrow> modal_depth_srbb_inner \<chi> | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct \<psi>) \<circ> \<psi>s)
-          ` (I - (revival_conjunct_index I \<psi>s))))
-          (Sup (neg_conjuncts ` (expr_pr_conjunct ` (\<psi>s ` I))))
-          (Sup ({1} \<union> neg_depth ` (expr_pr_conjunct ` (\<psi>s ` I))))\<close>
-        have subset_form: \<open>\<psi>qs ` (Q\<union>Qr) \<subseteq> \<psi>s ` I\<close>
-          using \<psi>qs_spec by fastforce
-        \<comment> \<open>TODO: encode this computation\<close>
-        term \<open>Sup (((\<lambda>\<psi>. case \<psi> of (Pos \<chi>) \<Rightarrow> modal_depth_srbb_inner \<chi> | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct \<psi>) \<circ> \<psi>s)
-          ` (I - (revival_conjunct_index I \<psi>s)))\<close>
-
-        hence \<open>e' \<le> eu'\<close> unfolding e'_def eu'_def
-          by (simp add: Sup_subset_mono image_mono sup.coboundedI2)
-        define e where \<open>e = E
-          (modal_depth e')
-          (br_conj_depth e')
-          (conj_depth e')
-          (1 + st_conj_depth e')
-          (imm_conj_depth e')
-          (pos_conjuncts e')
-          (pos_conjuncts_sec e')
-          (neg_conjuncts e')
-          (sup 1 (neg_depth e'))\<close>
-        have \<open>e' = e - (E 0 0 0 1 0 0 0 0 0)\<close> unfolding e_def e'_def by auto
-        hence \<open>Some e' = (subtract_fn 0 0 0 1 0 0 0 0 0) e\<close>
-          by (metis e_def energy.sel energy_leq_cases i0_lb le_iff_add)
-        have expr_lower: \<open>(E 0 0 0 1 0 0 0 0 0) \<le> expr_pr_inner (StableConj I \<psi>s)\<close>
-          using case_assms(1) subset_form by force
-        have eu'_comp: \<open>eu' = (expr_pr_inner (StableConj I \<psi>s)) - (E 0 0 0 1 0 0 0 0 0)\<close>
-          unfolding eu'_def using energy.sel
-          apply (auto simp add: bot_enat_def)
-          apply (metis (no_types, lifting) SUP_cong energy.sel image_image)
-          apply (metis (no_types, lifting) SUP_cong energy.sel image_image)
-          apply (metis (no_types, lifting) SUP_cong energy.sel image_image)
-          apply (metis (no_types, lifting) SUP_cong energy.sel image_image)
-          apply (metis (no_types, lifting) SUP_cong energy.sel image_image)
-             apply (metis (no_types, lifting) SUP_cong energy.sel image_image)
-          defer
-            apply (metis (no_types, lifting) SUP_cong energy.sel image_image)
-          apply (metis (no_types, lifting) energy.sel(9) image_cong image_image)
-          sledgehammer
-          apply (metis (no_types, lifting) SUP_cong energy.sel image_image)
-          apply (metis (no_types, lifting) SUP_cong image_image)
-          by (auto simp add: bot_enat_def, (metis (no_types, lifting) SUP_cong image_image)+)
-        with expr_lower have eu'_characterization: \<open>Some eu' = (subtract_fn 0 0 0 1 0 0 0 0) (expr_pr_inner (StableConj I \<psi>s))\<close>
-          by presburger
-        have \<open>\<forall>g'. spectroscopy_moves (Defender_Stable_Conj p Q) g' \<noteq> None
-        \<longrightarrow> (\<exists>q\<in>Q. (Attacker_Clause p q) = g') \<and> spectroscopy_moves (Defender_Stable_Conj p Q) g' = (subtract 0 0 0 1 0 0 0 0)\<close>
-        proof clarify
-          fix g' upd
-          assume upd_def: \<open>spectroscopy_moves (Defender_Stable_Conj p Q) g' = Some upd\<close>
-          hence \<open>\<And>px q. g' = Attacker_Clause px q \<Longrightarrow> p = px \<and> q \<in> Q \<and> upd = (subtract_fn 0 0 0 1 0 0 0 0)\<close>
-            by (metis (no_types, lifting) local.conj_s_answer option.discI option.inject)
-          with upd_def case_assms(1) show
-            \<open>(\<exists>q\<in>Q. Attacker_Clause p q = g') \<and> spectroscopy_moves (Defender_Stable_Conj p Q) g' = (subtract 0 0 0 1 0 0 0 0)\<close>
-            by (cases g', auto)
-        qed
-        hence \<open>\<forall>g'. spectroscopy_moves (Defender_Stable_Conj p Q) g' \<noteq> None
-          \<longrightarrow> (\<exists>e'. (the (spectroscopy_moves (Defender_Stable_Conj p Q) g')) e = Some e' \<and> attacker_wins e' g')\<close>
-          unfolding e_def
-          using clause_win \<open>Some e' = (subtract_fn 0 0 0 1 0 0 0 0) e\<close> e_def by force
-        hence \<open>attacker_wins e (Defender_Stable_Conj p Q)\<close>
-          unfolding e_def
-          by (auto simp add: attacker_wins.Defense)
-        moreover have \<open>e \<le> expr_pr_inner (StableConj I \<psi>s)\<close>
-          using \<open>e' \<le> eu'\<close> eu'_characterization \<open>Some e' = (subtract_fn 0 0 0 1 0 0 0 0) e\<close> expr_lower case_assms(1) subset_form
-          unfolding e_def eu'_comp minus_energy_def leq_components
-          by (metis add_diff_assoc_enat add_diff_cancel_enat add_left_mono enat.simps(3) enat_defs(2) energy.sel idiff_0_right)
-       ultimately show \<open>attacker_wins (expr_pr_inner (StableConj I \<psi>s)) (Defender_Stable_Conj p Q)\<close>
-          using win_a_upwards_closure by blast
       qed
       moreover have
         \<open>(\<forall>p Q. Q \<noteq> {} \<longrightarrow> hml_srbb_inner.distinguishes_from (StableConj I \<psi>s) p Q \<longrightarrow> Q \<Zsurj>S Q
-           \<longrightarrow> attacker_wins (expr_pr_inner (StableConj I \<psi>s)) (Attacker_Delayed p Q))\<close>
+           \<longrightarrow> attacker_wins (expr_pr_inner (StableConj I \<psi>s)) (Attacker_Delayed p Q))\<close> sorry
+      (*
       proof clarify
         \<comment> \<open>This is where things are more complicated than in the Conj-case. (We have to differentiate
             situations where the stability requirement finishes the distinction.)\<close>
@@ -799,7 +715,8 @@ proof-
             by (metis (mono_tags, lifting) mem_Collect_eq option.distinct(1) option.sel spectroscopy_defender.simps(4))
         qed
       qed
-      ultimately show ?case by blast
+*)
+      ultimately show ?case by auto
     next
       case (BranchConj \<alpha> \<phi> I \<psi>s)
       have main_case:
@@ -823,7 +740,7 @@ proof-
         hence inductive_wins: \<open>\<forall>q\<in>(Q \<inter> hml_srbb_inner.model_set (Obs \<alpha> \<phi>)).
           \<exists>i\<in>I. hml_srbb_conj.distinguishes (\<psi>s i) p q
             \<and> attacker_wins (expr_pr_conjunct (\<psi>s i)) (Attacker_Clause p q)\<close>
-          using BranchConj by blast
+          using BranchConj by (meson rangeI)
         define \<psi>qs where
           \<open>\<psi>qs \<equiv> \<lambda>q. (SOME \<psi>. \<exists>i\<in>I. \<psi> = \<psi>s i \<and>  hml_srbb_conj.distinguishes \<psi> p q
             \<and> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Clause p q))\<close>
@@ -843,6 +760,7 @@ proof-
           (Sup (st_conj_depth  ` (expr_pr_conjunct ` (\<psi>qs ` (Q \<inter> hml_srbb_inner.model_set (Obs \<alpha> \<phi>))))))
           (Sup (imm_conj_depth  ` (expr_pr_conjunct ` (\<psi>qs ` (Q \<inter> hml_srbb_inner.model_set (Obs \<alpha> \<phi>))))))
           (Sup (pos_conjuncts   ` (expr_pr_conjunct ` (\<psi>qs ` (Q \<inter> hml_srbb_inner.model_set (Obs \<alpha> \<phi>))))))
+          (Sup (pos_conjuncts_sec   ` (expr_pr_conjunct ` (\<psi>qs ` (Q \<inter> hml_srbb_inner.model_set (Obs \<alpha> \<phi>))))))
           (Sup (neg_conjuncts ` (expr_pr_conjunct ` (\<psi>qs ` (Q \<inter> hml_srbb_inner.model_set (Obs \<alpha> \<phi>))))))
           (Sup (neg_depth ` (expr_pr_conjunct ` (\<psi>qs ` (Q \<inter> hml_srbb_inner.model_set (Obs \<alpha> \<phi>))))))\<close>
         from conjuncts_present have branch_answer_bound:
@@ -858,6 +776,7 @@ proof-
           (Sup (st_conj_depth  ` (expr_pr_conjunct ` (\<psi>s ` I))))
           (Sup (imm_conj_depth  ` (expr_pr_conjunct ` (\<psi>s ` I))))
           (Sup (pos_conjuncts   ` (expr_pr_conjunct ` (\<psi>s ` I))))
+          (Sup (pos_conjuncts_sec   ` (expr_pr_conjunct ` (\<psi>s ` I))))
           (Sup (neg_conjuncts ` (expr_pr_conjunct ` (\<psi>s ` I))))
           (Sup (neg_depth ` (expr_pr_conjunct ` (\<psi>s ` I))))\<close>
         have subset_form: \<open>\<psi>qs ` (Q \<inter> hml_srbb_inner.model_set (Obs \<alpha> \<phi>)) \<subseteq> \<psi>s ` I\<close>
@@ -875,11 +794,11 @@ proof-
         with BranchConj have win_a_branch:
           \<open>attacker_wins (expressiveness_price \<phi>) (Attacker_Immediate p' Q')\<close>
           using distinction_implies_winning_budgets_empty_Q by (cases \<open>Q' = {}\<close>) auto
-        have \<open>expr_pr_inner (Obs \<alpha> \<phi>) \<ge> (E 1 0 0 0 0 0 0 0)\<close> by auto
-        hence \<open>(subtract_fn 1 0 0 0 0 0 0 0) (expr_pr_inner (Obs \<alpha> \<phi>)) = Some (expressiveness_price \<phi>)\<close>
+        have \<open>expr_pr_inner (Obs \<alpha> \<phi>) \<ge> (E 1 0 0 0 0 0 0 0 0)\<close> by auto
+        hence \<open>(subtract_fn 1 0 0 0 0 0 0 0 0) (expr_pr_inner (Obs \<alpha> \<phi>)) = Some (expressiveness_price \<phi>)\<close>
           using expr_obs_phi by auto
         with win_a_branch have win_a_step:
-          \<open>attacker_wins (the ((subtract_fn 1 0 0 0 0 0 0 0) (expr_pr_inner (Obs \<alpha> \<phi>)))) (Attacker_Immediate p' Q')\<close> by auto
+          \<open>attacker_wins (the ((subtract_fn 1 0 0 0 0 0 0 0 0) (expr_pr_inner (Obs \<alpha> \<phi>)))) (Attacker_Immediate p' Q')\<close> by auto
         define e' where \<open>e' = E
           (Sup (modal_depth   ` ({expr_pr_inner (Obs \<alpha> \<phi>)} \<union> (expr_pr_conjunct ` (\<psi>s ` I)))))
           (Sup (br_conj_depth   ` ({expr_pr_inner (Obs \<alpha> \<phi>)} \<union> (expr_pr_conjunct ` (\<psi>s ` I)))))
@@ -888,11 +807,12 @@ proof-
           (Sup (imm_conj_depth  ` ({expr_pr_inner (Obs \<alpha> \<phi>)} \<union> (expr_pr_conjunct ` (\<psi>s ` I)))))
           (Sup ({1 + modal_depth_srbb \<phi>}
              \<union> (pos_conjuncts   ` ({expr_pr_inner (Obs \<alpha> \<phi>)} \<union> (expr_pr_conjunct ` (\<psi>s ` I))))))
+          (Sup (pos_conjuncts_sec   ` ({expr_pr_inner (Obs \<alpha> \<phi>)} \<union> (expr_pr_conjunct ` (\<psi>s ` I)))))
           (Sup (neg_conjuncts ` ({expr_pr_inner (Obs \<alpha> \<phi>)} \<union> (expr_pr_conjunct ` (\<psi>s ` I)))))
           (Sup (neg_depth ` ({expr_pr_inner (Obs \<alpha> \<phi>)} \<union> (expr_pr_conjunct ` (\<psi>s ` I)))))\<close>
         have \<open>eu'0 \<le> e'\<close> unfolding e'_def eu'0_def
           by (auto, meson sup.cobounded2 sup.coboundedI2)
-        have \<open>spectroscopy_moves (Attacker_Branch p' Q') (Attacker_Immediate p' Q') = Some (subtract_fn 1 0 0 0 0 0 0 0)\<close> by simp
+        have \<open>spectroscopy_moves (Attacker_Branch p' Q') (Attacker_Immediate p' Q') = Some (subtract_fn 1 0 0 0 0 0 0 0 0)\<close> by simp
         with win_a_step attacker_wins_Ga have obs_later_win: \<open>attacker_wins (expr_pr_inner (Obs \<alpha> \<phi>)) (Attacker_Branch p' Q')\<close>
           by force
         hence e'_win: \<open>attacker_wins e' (Attacker_Branch p' Q')\<close>
@@ -915,6 +835,7 @@ proof-
           (Sup (st_conj_depth  ` ({expr_pr_inner (Obs \<alpha> \<phi>)} \<union> (expr_pr_conjunct ` (\<psi>s ` I)))))
           (Sup (imm_conj_depth  ` ({expr_pr_inner (Obs \<alpha> \<phi>)} \<union> (expr_pr_conjunct ` (\<psi>s ` I)))))
           (Sup ({1 + modal_depth_srbb \<phi>} \<union> (pos_conjuncts ` ({expr_pr_inner (Obs \<alpha> \<phi>)} \<union> (expr_pr_conjunct ` (\<psi>s ` I))))))
+          (Sup (pos_conjuncts_sec ` ({expr_pr_inner (Obs \<alpha> \<phi>)} \<union> (expr_pr_conjunct ` (\<psi>s ` I)))))
           (Sup (neg_conjuncts ` ({expr_pr_inner (Obs \<alpha> \<phi>)} \<union> (expr_pr_conjunct ` (\<psi>s ` I)))))
           (Sup (neg_depth ` ({expr_pr_inner (Obs \<alpha> \<phi>)} \<union> (expr_pr_conjunct ` (\<psi>s ` I))))))\<close>
           using e'_def min1_6_def six_e'_simp
@@ -930,42 +851,45 @@ proof-
           (st_conj_depth e')
           (imm_conj_depth e')
           (pos_conjuncts e')
+          (pos_conjuncts_sec e')
           (neg_conjuncts e')
           (neg_depth e')\<close>
-        have \<open>e' = e - (E 0 1 1 0 0 0 0 0)\<close> unfolding e_def e'_def by auto
-        hence e'_comp: \<open>Some e' = (subtract_fn 0 1 1 0 0 0 0 0) e\<close>
+        have \<open>e' = e - (E 0 1 1 0 0 0 0 0 0)\<close> unfolding e_def e'_def by auto
+        hence e'_comp: \<open>Some e' = (subtract_fn 0 1 1 0 0 0 0 0 0) e\<close>
           by (metis e_def energy.sel energy_leq_cases i0_lb le_iff_add)
-        have expr_lower: \<open>(E 0 1 1 0 0 0 0 0) \<le> expr_pr_inner (BranchConj \<alpha> \<phi> I \<psi>s)\<close>
+        have expr_lower: \<open>(E 0 1 1 0 0 0 0 0 0) \<le> expr_pr_inner (BranchConj \<alpha> \<phi> I \<psi>s)\<close>
           using case_assms subset_form by auto
-        have e'_minus: \<open>e' = expr_pr_inner (BranchConj \<alpha> \<phi> I \<psi>s) - E 0 1 1 0 0 0 0 0\<close>
+        have e'_minus: \<open>e' = expr_pr_inner (BranchConj \<alpha> \<phi> I \<psi>s) - E 0 1 1 0 0 0 0 0 0\<close>
           unfolding e'_def using energy.sel
           by (auto simp add: bot_enat_def sup.left_commute,
              (metis (no_types, lifting) SUP_cong image_image)+)
         with expr_lower have e'_characterization:
-            \<open>Some e' = (subtract_fn 0 1 1 0 0 0 0 0) (expr_pr_inner (BranchConj \<alpha> \<phi> I \<psi>s))\<close>
+            \<open>Some e' = (subtract_fn 0 1 1 0 0 0 0 0 0) (expr_pr_inner (BranchConj \<alpha> \<phi> I \<psi>s))\<close>
           by presburger
         have moves: \<open>\<forall>g'. spectroscopy_moves (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>) g' \<noteq> None
         \<longrightarrow> (((Attacker_Branch p' Q' = g')
-            \<and> (spectroscopy_moves (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>) g' = Some (\<lambda>e. Option.bind ((subtract_fn 0 1 1 0 0 0 0 0) e) min1_6)))
+            \<and> (spectroscopy_moves (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>) g' = Some (\<lambda>e. Option.bind ((subtract_fn 0 1 1 0 0 0 0 0 0) e) min1_6)))
           \<or> ((\<exists>q\<in>(Q - Q_\<alpha>). Attacker_Clause p q = g'
-            \<and> spectroscopy_moves (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>) g' = (subtract 0 1 1 0 0 0 0 0))))\<close>
+            \<and> spectroscopy_moves (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>) g' = (subtract 0 1 1 0 0 0 0 0 0))))\<close>
         proof clarify
           fix g' u
           assume no_subtr_move:
             \<open>spectroscopy_moves (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>) g' = Some u\<close>
-            \<open>\<not> (\<exists>q\<in>Q - Q_\<alpha>. Attacker_Clause p q = g' \<and> spectroscopy_moves (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>) g' = subtract 0 1 1 0 0 0 0 0)\<close>
+            \<open>\<not> (\<exists>q\<in>Q - Q_\<alpha>. Attacker_Clause p q = g' \<and> spectroscopy_moves (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>) g' = subtract 0 1 1 0 0 0 0 0 0)\<close>
           hence \<open>g' = Attacker_Branch p' Q'\<close>
             unfolding Q'_def using soft_step_set_is_soft_step_set no_subtr_move local.br_answer
             by (cases g', auto, (metis (no_types, lifting)  option.discI)+)
-          moreover have \<open>Attacker_Branch p' Q' = g' \<longrightarrow> spectroscopy_moves (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>) g' =  Some (\<lambda>e. Option.bind ((subtract_fn 0 1 1 0 0 0 0 0) e) min1_6)\<close>
+          moreover have \<open>Attacker_Branch p' Q' = g'
+              \<longrightarrow> spectroscopy_moves (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>) g' =  Some (\<lambda>e. Option.bind ((subtract_fn 0 1 1 0 0 0 0 0 0) e) min1_6)\<close>
             unfolding Q'_def using soft_step_set_is_soft_step_set by auto
-          ultimately show \<open>Attacker_Branch p' Q' = g' \<and> spectroscopy_moves (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>) g' =  Some (\<lambda>e. Option.bind ((subtract_fn 0 1 1 0 0 0 0 0) e) min1_6)\<close>
+          ultimately show \<open>Attacker_Branch p' Q' = g'
+              \<and> spectroscopy_moves (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>) g' =  Some (\<lambda>e. Option.bind ((subtract_fn 0 1 1 0 0 0 0 0 0) e) min1_6)\<close>
             by blast
         qed
-        have obs_e: \<open>\<exists>e'. (\<lambda>e. Option.bind ((subtract_fn 0 1 1 0 0 0 0 0) e) min1_6) e = Some e' \<and> attacker_wins e' (Attacker_Branch p' Q')\<close>
+        have obs_e: \<open>\<exists>e'. (\<lambda>e. Option.bind ((subtract_fn 0 1 1 0 0 0 0 0 0) e) min1_6) e = Some e' \<and> attacker_wins e' (Attacker_Branch p' Q')\<close>
           using obs_win e'_comp min_e'_def
-          by (smt (verit, best) bind.bind_lunit min_1_6_some option.collapse)
-        have \<open>\<forall>q\<in>(Q - Q_\<alpha>). spectroscopy_moves (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>) (Attacker_Clause p q) = (subtract 0 1 1 0 0 0 0 0)
+          by (smt (verit, best) bind.bind_lunit min_some option.collapse)
+        have \<open>\<forall>q\<in>(Q - Q_\<alpha>). spectroscopy_moves (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>) (Attacker_Clause p q) = (subtract 0 1 1 0 0 0 0 0 0)
           \<longrightarrow> attacker_wins e'0 (Attacker_Clause p q)\<close>
           using conj_wins \<open>eu'0 \<le> e'\<close> case_assms(4) by blast
         with obs_e moves have move_wins: \<open>\<forall>g'. spectroscopy_moves (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>) g' \<noteq> None
@@ -975,7 +899,7 @@ proof-
         moreover have \<open>expr_pr_inner (BranchConj \<alpha> \<phi> I \<psi>s) = e\<close>
           using e'_characterization e'_minus unfolding e_def by force
         ultimately show \<open>attacker_wins (expr_pr_inner (BranchConj \<alpha> \<phi> I \<psi>s)) (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>)\<close>
-        using attacker_wins.Defense spectroscopy_defender.simps(5)
+        using attacker_wins.Defense spectroscopy_defender.simps(6)
           by metis
       qed
       moreover have
@@ -1000,7 +924,7 @@ proof-
     next
       case (Pos \<chi>)
       show ?case
-      proof clarify
+      proof safe
         fix p q
         assume case_assms: \<open>hml_srbb_conj.distinguishes (Pos \<chi>) p q\<close>
         then obtain p' where p'_spec: \<open>p \<Zsurj> p'\<close> \<open>p' \<in> hml_srbb_inner.model_set \<chi>\<close>
@@ -1019,14 +943,43 @@ proof-
           using distinction Pos by blast
         from p'_spec(1) this have \<open>attacker_wins (expr_pr_inner \<chi>) (Attacker_Delayed p (silent_reachable_set {q}))\<close>
           by (induct, auto,
-              metis attacker_wins_Ga_with_id_step local.procrastination option.distinct(1) option.sel spectroscopy_defender.simps(4))
+              metis attacker_wins_Ga_with_id_step local.procrastination option.distinct(1) option.sel spectroscopy_defender.simps(5))
         moreover have \<open>spectroscopy_moves (Attacker_Clause p q) (Attacker_Delayed p (silent_reachable_set {q})) = Some min1_6\<close>
           using q_reach_nonempty sreachable_set_is_sreachable by fastforce
         moreover have \<open>the (min1_6 (expr_pr_conjunct (Pos \<chi>))) \<ge> expr_pr_inner \<chi>\<close>
           unfolding min1_6_def by (auto simp add: energy_leq_cases modal_depth_dominates_pos_conjuncts)
         ultimately show \<open>attacker_wins (expr_pr_conjunct (Pos \<chi>)) (Attacker_Clause p q)\<close>
           using attacker_wins_Ga win_a_upwards_closure spectroscopy_defender.simps(3)
-          by (metis (no_types, lifting) min_1_6_some option.discI option.exhaust_sel option.sel)
+          by (metis (no_types, lifting) min_some(1) option.discI option.exhaust_sel option.sel)
+      next
+        fix p q e'
+        have order: \<open>\<forall>\<chi>. max_pos_conj_secondary_depth_inner \<chi> \<le> modal_depth_srbb_inner \<chi>\<close>
+          using max_positive_conjunct_depth_dominates_secondary(2) modal_depth_dominates_pos_conjuncts
+          using order.trans by blast
+        assume case_assms:
+          \<open>hml_srbb_conj.distinguishes (Pos \<chi>) p q\<close>
+          \<open>stable_state p\<close> \<open>stable_state q\<close>
+          \<open>expr_pr_conjunct (Pos \<chi>) \<le> e'\<close> \<open>pos_conjuncts e' \<le> pos_conjuncts_sec e'\<close>
+        hence \<open>hml_srbb_inner.distinguishes_from \<chi> p {q}\<close>
+          using stable_state_stable silent_reachable.refl
+          by auto
+        hence \<open>attacker_wins (expr_pr_inner \<chi>) (Attacker_Delayed p {q})\<close>
+          using Pos stable_state_stabilized[OF \<open>stable_state q\<close>]
+          by auto
+        moreover have \<open>spectroscopy_moves (Attacker_Stable_Clause p q) (Attacker_Delayed p {q}) = Some min1_7\<close>
+          by fastforce
+        moreover have \<open>the (min1_6 (expr_pr_conjunct (Pos \<chi>))) \<ge> expr_pr_inner \<chi>\<close>
+          unfolding min1_6_def by (auto simp add: energy_leq_cases modal_depth_dominates_pos_conjuncts)
+        moreover hence \<open>the (min1_7 e') \<ge> expr_pr_inner \<chi>\<close>
+          using case_assms by auto
+        ultimately have
+            \<open>attacker_wins e' (Attacker_Stable_Clause p q)\<close>
+          using attacker_wins_Ga win_a_upwards_closure spectroscopy_defender.simps(4)
+          by (metis (mono_tags, lifting) min_some(2) not_None_eq option.sel)
+      next
+        show \<open>\<And>p q e'.
+       hml_srbb_conj.distinguishes (Pos \<chi>) p q \<Longrightarrow>
+       stable_state p \<Longrightarrow> stable_state q \<Longrightarrow> expr_pr_conjunct (Pos \<chi>) \<le> e' \<Longrightarrow> pos_conjuncts e' \<le> pos_conjuncts_sec e' \<Longrightarrow> attacker_wins e' (Attacker_Stable_Clause p q)\<close> sorry
       qed
     next
       case (Neg \<chi>)

--- a/Distinction_Implies_Winning_Budgets.thy
+++ b/Distinction_Implies_Winning_Budgets.thy
@@ -29,16 +29,28 @@ text \<open>In this section, we prove that if a formula distinguishes a process 
       to the defender position @{term \<open>Defender_Conj p {}\<close>}. In this position the defender is then
       unable to make any further moves. Hence, the attacker wins the game with any budget.\<close>
 
+lemma defender_conj_empty_att_wins:
+  shows \<open>attacker_wins e (Defender_Conj p {})\<close>
+proof -
+  have is_last_move: \<open>spectroscopy_moves (Defender_Conj p {}) g' = None\<close> for g'
+    by(rule spectroscopy_moves.elims, auto)
+  moreover have \<open>spectroscopy_defender (Defender_Conj p {})\<close> by simp
+  ultimately show \<open>attacker_wins e (Defender_Conj p {})\<close>
+    by (simp add: attacker_wins.Defense)
+qed
+
+lemma att_empty_att_wins:
+  shows \<open>attacker_wins e (Attacker_Delayed p {})\<close>
+proof -
+  have \<open>spectroscopy_moves (Attacker_Delayed p {}) (Defender_Conj p {}) = Some Some\<close> by simp
+  thus ?thesis
+    using defender_conj_empty_att_wins Attack spectroscopy_defender.simps(5) by fastforce
+qed
+
 lemma distinction_implies_winning_budgets_empty_Q:
   assumes \<open>distinguishes_from \<phi> p {}\<close>
   shows \<open>attacker_wins (expressiveness_price \<phi>) (Attacker_Immediate p {})\<close>
 proof-
-  have is_last_move: \<open>spectroscopy_moves (Defender_Conj p {}) p' = None\<close> for p'
-    by(rule spectroscopy_moves.elims, auto)
-  moreover have \<open>spectroscopy_defender (Defender_Conj p {})\<close> by simp
-  ultimately have conj_win: \<open>attacker_wins (expressiveness_price \<phi>) (Defender_Conj p {})\<close>
-    by (simp add: attacker_wins.Defense)
-
   from late_inst_conj[of p \<open>{}\<close> p \<open>{}\<close>] have next_move0:
     \<open>spectroscopy_moves (Attacker_Delayed p {}) (Defender_Conj p {}) = Some Some\<close> by force
 
@@ -47,7 +59,7 @@ proof-
 
   moreover have \<open>attacker (Attacker_Immediate p {})\<close> by simp
   ultimately show ?thesis using attacker_wins.Attack[of \<open>Attacker_Immediate p {}\<close> _ \<open>expressiveness_price \<phi>\<close>]
-    using next_move0 next_move1 attacker_wins_Ga_with_id_step conj_win
+    using next_move0 next_move1 attacker_wins_Ga_with_id_step[OF defender_conj_empty_att_wins]
     by fastforce
 qed
 
@@ -428,20 +440,205 @@ proof-
         hence distinctions: \<open>\<forall>q\<in>Q\<union>Qr. \<exists>i\<in>I. hml_srbb_conj.distinguishes (\<psi>s i) p q\<close>
           by simp
         hence inductive_wins: \<open>\<forall>q\<in>Q\<union>Qr. \<exists>i\<in>I. hml_srbb_conj.distinguishes (\<psi>s i) p q
+            \<and> attacker_wins (expr_pr_conjunct (\<psi>s i)) (Attacker_Clause p q)
             \<and> attacker_wins (expr_pr_conjunct (\<psi>s i)) (Attacker_Stable_Clause p q)\<close>
           using StableConj by blast
         define \<psi>qs where
           \<open>\<psi>qs \<equiv> \<lambda>q. (SOME \<psi>. \<exists>i\<in>I. \<psi> = \<psi>s i \<and>  hml_srbb_conj.distinguishes \<psi> p q
+            \<and> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Clause p q)
             \<and> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Stable_Clause p q))\<close>
         with inductive_wins someI have \<psi>qs_spec:
           \<open>\<forall>q\<in>Q\<union>Qr. \<exists>i\<in>I. \<psi>qs q = \<psi>s i \<and> hml_srbb_conj.distinguishes (\<psi>qs q ) p q
+            \<and> attacker_wins (expr_pr_conjunct (\<psi>qs q)) (Attacker_Clause p q)
             \<and> attacker_wins (expr_pr_conjunct (\<psi>qs q)) (Attacker_Stable_Clause p q)\<close>
           by (smt (verit))
+        have conjuncts_present: \<open>\<forall>q\<in>Q. expr_pr_conjunct (\<psi>qs q) \<in> expr_pr_conjunct ` (\<psi>qs ` Q)\<close>
+          using \<open>Q \<noteq> {}\<close> by blast
+        define e' where \<open>e' = E
+          (Sup (modal_depth   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup (br_conj_depth   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup (conj_depth ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup (st_conj_depth  ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup (imm_conj_depth  ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup (pos_conjuncts   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))
+                \<union> pos_conjuncts_sec   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup (pos_conjuncts_sec   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup (neg_conjuncts ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup ({1} \<union> neg_depth ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))\<close>
+        from conjuncts_present have conj_prices: \<open>\<forall>q\<in>Q\<union>Qr. (expr_pr_conjunct (\<psi>qs q)) \<le> e'\<close> unfolding e'_def
+          by (smt (z3) Sup_upper UnI1 UnI2 energy.sel image_insert insert_iff leq_components mk_disjoint_insert)
+        hence clause_win: \<open>\<forall>q\<in>Q. attacker_wins e' (Attacker_Stable_Clause p q)\<close>
+          using \<psi>qs_spec win_a_upwards_closure by blast
+        have clause_win_revivals: \<open>attacker_wins e' (Attacker_Delayed p Qr)\<close>
+          using conj_prices \<psi>qs_spec win_a_upwards_closure sorry
         define revivals where \<open>revivals \<equiv> revival_conjunct_index I \<psi>s\<close>
         show \<open>attacker_wins (expr_pr_inner (StableConj I \<psi>s)) (Defender_Stable_Conj p Q Qr)\<close>
         proof (cases \<open>revivals = {}\<close>)
           case True
-          then show ?thesis sorry
+          define eu' where \<open>eu' = E
+            (Sup (modal_depth   ` (expr_pr_conjunct ` (\<psi>s ` I))))
+            (Sup (br_conj_depth   ` (expr_pr_conjunct ` (\<psi>s ` I))))
+            (Sup (conj_depth ` (expr_pr_conjunct ` (\<psi>s ` I))))
+            (Sup (st_conj_depth  ` (expr_pr_conjunct ` (\<psi>s ` I))))
+            (Sup (imm_conj_depth  ` (expr_pr_conjunct ` (\<psi>s ` I))))
+            (Sup (pos_conjuncts   ` (expr_pr_conjunct ` (\<psi>s ` I))))
+            (Sup (((\<lambda>\<psi>. case \<psi> of (Pos \<chi>) \<Rightarrow> modal_depth_srbb_conjunct \<psi> | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct \<psi>) \<circ> \<psi>s)
+            ` I ))
+            (Sup (neg_conjuncts ` (expr_pr_conjunct ` (\<psi>s ` I))))
+            (Sup ({1} \<union> neg_depth ` (expr_pr_conjunct ` (\<psi>s ` I))))\<close>
+          have secondary_conjs: \<open>\<forall>i\<in>I. (max_pos_conj_secondary_depth_conjunct (\<psi>s i)
+                 \<le> (case \<psi>s i of
+                      Pos \<chi> \<Rightarrow> modal_depth_srbb_conjunct (\<psi>s i)
+                    | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct (\<psi>s i)))\<close>
+            using modal_depth_dominates_pos_conjuncts max_positive_conjunct_depth_dominates_secondary(3)
+            by (metis hml_srbb_conjunct.case_eq_if order.trans order_class.order_eq_iff)
+          hence \<open>Sup { max_pos_conj_secondary_depth_conjunct (\<psi>s i) |i. i \<in> I }
+                 \<le> Sup { case (\<psi>s i) of
+                      Pos \<chi> \<Rightarrow> modal_depth_srbb_conjunct (\<psi>s i)
+                    | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct (\<psi>s i) |i. i \<in> I }\<close>
+            by (smt (verit, ccfv_SIG) Sup_mono mem_Collect_eq)
+          moreover have equal_sets:
+            \<open>{ max_pos_conj_secondary_depth_conjunct (\<psi>s i) |i. i \<in> I } = max_pos_conj_secondary_depth_conjunct ` \<psi>s ` I\<close>
+            \<open>{ case (\<psi>s i) of
+                      Pos \<chi> \<Rightarrow> modal_depth_srbb_conjunct (\<psi>s i)
+                    | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct (\<psi>s i) |i. i \<in> I } = (\<lambda>\<psi>. case \<psi> of
+                      Pos \<chi> \<Rightarrow> modal_depth_srbb_conjunct \<psi>
+                    | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct \<psi>) ` \<psi>s ` I\<close>
+            by auto
+          ultimately have \<open>Sup (max_pos_conj_secondary_depth_conjunct ` \<psi>s ` I)
+                 \<le> Sup ((\<lambda>\<psi>. case \<psi> of
+                      Pos \<chi> \<Rightarrow> modal_depth_srbb_conjunct \<psi>
+                    | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct \<psi>) ` \<psi>s ` I )\<close>
+            by simp
+          moreover have subset_form: \<open>\<psi>qs ` (Q\<union>Qr) \<subseteq> \<psi>s ` I\<close>
+            using \<psi>qs_spec by fastforce
+          ultimately have sup_Q_I: \<open>Sup (max_pos_conj_secondary_depth_conjunct ` \<psi>qs ` (Q\<union>Qr))
+                 \<le> Sup ((\<lambda>\<psi>. case \<psi> of
+                      Pos \<chi> \<Rightarrow> modal_depth_srbb_conjunct \<psi>
+                    | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct \<psi>) ` \<psi>s ` I )\<close>
+            by (smt (verit, best) Orderings.order_eq_iff SUP_subset_mono order_trans)
+          hence \<open>e' \<le> eu'\<close>
+            unfolding e'_def eu'_def
+            using subset_form
+            apply (auto simp add: Sup_subset_mono image_mono sup.coboundedI2)
+             defer
+            apply
+               (smt (z3) SUP_cong Sup_le_iff Sup_upper sup_Q_I equal_sets(2) dual_order.trans
+                energy.sel(7) image_iff image_image mem_Collect_eq)
+            proof -
+              assume a1: "\<psi>qs ` (Q \<union> Qr) \<subseteq> \<psi>s ` I"
+              obtain ee :: "enat \<Rightarrow> enat set \<Rightarrow> enat" where
+                f2: "\<forall>x0 x1. (\<exists>v2. v2 \<in> x1 \<and> \<not> v2 \<le> x0) = (ee x0 x1 \<in> x1 \<and> \<not> ee x0 x1 \<le> x0)"
+                by moura
+              obtain hh :: "(('a, 's) hml_srbb_conjunct \<Rightarrow> enat) \<Rightarrow> (('a, 's) hml_srbb_conjunct \<Rightarrow> enat) \<Rightarrow> ('a, 's) hml_srbb_conjunct set \<Rightarrow> ('a, 's) hml_srbb_conjunct" where
+                f3: "\<forall>x0 x1 x3. (\<exists>v4. v4 \<in> x3 \<and> \<not> x1 v4 \<le> x0 v4) = (hh x0 x1 x3 \<in> x3 \<and> \<not> x1 (hh x0 x1 x3) \<le> x0 (hh x0 x1 x3))"
+                by moura
+              have f4: "\<forall>E e. (\<not> Sup E \<le> e \<or> (\<forall>ea. ea \<notin> E \<or> ea \<le> e)) \<and> (Sup E \<le> e \<or> ee e E \<in> E \<and> \<not> ee e E \<le> e)"
+                using f2 by (metis (no_types) Sup_le_iff)
+              have f5: "\<forall>H Ha f fa. \<not> H \<subseteq> Ha \<or> hh fa f H \<in> H \<and> \<not> f (hh fa f H) \<le> fa (hh fa f H) \<or> Sup (f ` H) \<le> Sup (fa ` Ha)"
+                using f3 by (metis SUP_subset_mono)
+              then have f6: "\<forall>e. e \<notin> (\<lambda>h. pos_conjuncts_sec (E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h))) ` \<psi>qs ` (Q \<union> Qr) \<or> e \<le> Sup (pos_conjuncts ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>s ` I)"
+                using f4 a1 by (smt (z3) energy.sel(6) energy.sel(7) image_image max_positive_conjunct_depth_dominates_secondary(3))
+              have "\<forall>e. e \<notin> (\<lambda>h. pos_conjuncts (E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h))) ` \<psi>qs ` (Q \<union> Qr) \<or> e \<le> Sup (pos_conjuncts ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>s ` I)"
+                using f5 f4 a1 by (smt (z3) image_image nle_le)
+              then have "ee (Sup (pos_conjuncts ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>s ` I)) (pos_conjuncts ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>qs ` (Q \<union> Qr) \<union> pos_conjuncts_sec ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>qs ` (Q \<union> Qr)) \<notin> pos_conjuncts ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>qs ` (Q \<union> Qr) \<union> pos_conjuncts_sec ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>qs ` (Q \<union> Qr) \<or> ee (Sup (pos_conjuncts ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>s ` I)) (pos_conjuncts ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>qs ` (Q \<union> Qr) \<union> pos_conjuncts_sec ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>qs ` (Q \<union> Qr)) \<le> Sup (pos_conjuncts ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>s ` I)"
+                using f6 by blast
+              then show "Sup (pos_conjuncts ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>qs ` (Q \<union> Qr) \<union> pos_conjuncts_sec ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>qs ` (Q \<union> Qr)) \<le> Sup (pos_conjuncts ` (\<lambda>h. E (modal_depth_srbb_conjunct h) (branch_conj_depth_conjunct h) (inst_conj_depth_conjunct h) (st_conj_depth_conjunct h) (imm_conj_depth_conjunct h) (max_pos_conj_depth_conjunct h) (max_pos_conj_secondary_depth_conjunct h) (max_neg_conj_depth_conjunct h) (neg_depth_conjunct h)) ` \<psi>s ` I)"
+                using f4 by meson
+            qed
+          define e where \<open>e = E
+            (modal_depth e')
+            (br_conj_depth e')
+            (conj_depth e')
+            (1 + st_conj_depth e')
+            (imm_conj_depth e')
+            (pos_conjuncts e')
+            (pos_conjuncts_sec e')
+            (neg_conjuncts e')
+            (sup 1 (neg_depth e'))\<close>
+          have \<open>e' = e - (E 0 0 0 1 0 0 0 0 0)\<close> unfolding e_def e'_def by auto
+          hence \<open>Some e' = (subtract_fn 0 0 0 1 0 0 0 0 0) e\<close>
+            by (metis e_def energy.sel energy_leq_cases i0_lb le_iff_add)
+          have expr_lower: \<open>(E 0 0 0 1 0 0 0 0 0) \<le> expr_pr_inner (StableConj I \<psi>s)\<close>
+            using case_assms(1) subset_form by force
+          have eu'_comp: \<open>eu' = (expr_pr_inner (StableConj I \<psi>s)) - (E 0 0 0 1 0 0 0 0 0)\<close>
+            using energy.sel True
+            unfolding eu'_def revivals_def 
+            by (auto simp add: bot_enat_def hml_srbb_conjunct.case_eq_if image_image)
+              (smt (verit, ccfv_threshold) Int_Collect SUP_cong Sup_union_distrib
+                    hml_srbb_conjunct.collapse(1) modal_depth_srbb_rewrite)
+          with expr_lower have eu'_characterization: \<open>Some eu' = (subtract_fn 0 0 0 1 0 0 0 0 0) (expr_pr_inner (StableConj I \<psi>s))\<close>
+            by presburger
+          have moves: \<open>\<forall>g'. spectroscopy_moves (Defender_Stable_Conj p Q Qr) g' \<noteq> None
+          \<longrightarrow> ((\<exists>q\<in>Q. (Attacker_Stable_Clause p q) = g') \<and> spectroscopy_moves (Defender_Stable_Conj p Q Qr) g'
+                 = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 1 0 0 0 0 0) e) min6_7)
+            \<or> Attacker_Delayed p Qr = g' \<and> spectroscopy_moves (Defender_Stable_Conj p Q Qr) g'
+                 = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 1 0 0 0 0 0) e) min1_6)
+            \<or> Defender_Conj p {} = g' \<and> spectroscopy_moves (Defender_Stable_Conj p Q Qr) g'
+                 = (subtract 0 0 0 1 0 0 0 0 1))\<close>
+          proof (rule, rule)
+            fix g'
+            assume case_assm: \<open>spectroscopy_moves (Defender_Stable_Conj p Q Qr) g' \<noteq> None\<close>
+            then obtain upd where
+                \<open>spectroscopy_moves (Defender_Stable_Conj p Q Qr) g' = Some upd\<close>
+                \<open>None \<noteq> Some upd\<close>
+              by blast
+            thus \<open>(\<exists>q\<in>Q. Attacker_Stable_Clause p q = g') \<and>
+              spectroscopy_moves (Defender_Stable_Conj p Q Qr) g' =
+              Some (\<lambda>e. Option.bind (if \<not> E 0 0 0 1 0 0 0 0 0 \<le> e then None else Some (e - E 0 0 0 1 0 0 0 0 0)) min6_7) \<or>
+              Attacker_Delayed p Qr = g' \<and>
+              spectroscopy_moves (Defender_Stable_Conj p Q Qr) g' =
+              Some (\<lambda>e. Option.bind (if \<not> E 0 0 0 1 0 0 0 0 0 \<le> e then None else Some (e - E 0 0 0 1 0 0 0 0 0)) min1_6) \<or>
+              Defender_Conj p {} = g' \<and>
+              spectroscopy_moves (Defender_Stable_Conj p Q Qr) g' =
+              Some (\<lambda>x. if \<not> E 0 0 0 1 0 0 0 0 1 \<le> x then None else Some (x - E 0 0 0 1 0 0 0 0 1))\<close>
+              using case_assm conj_s_answer conj_s_revival empty_stbl_conj_answer
+              by (cases g') (metis (no_types, lifting) | simp)+
+          qed
+          have \<open>\<forall>g'. spectroscopy_moves (Defender_Stable_Conj p Q Qr) g' \<noteq> None
+            \<longrightarrow> (\<exists>e'. (the (spectroscopy_moves (Defender_Stable_Conj p Q Qr) g')) e = Some e' \<and> attacker_wins e' g')\<close>
+          proof safe
+            fix g' eu
+            assume \<open>spectroscopy_moves (Defender_Stable_Conj p Q Qr) g' = Some eu\<close>
+            then consider 
+                (stable_answer)
+                  \<open>(\<exists>q\<in>Q. Attacker_Stable_Clause p q = g')\<close>
+                  \<open>spectroscopy_moves (Defender_Stable_Conj p Q Qr) g' =
+                    Some (\<lambda>e. Option.bind (if \<not> E 0 0 0 1 0 0 0 0 0 \<le> e then None else Some (e - E 0 0 0 1 0 0 0 0 0)) min6_7)\<close>
+              | (stable_revival)
+                  \<open>Attacker_Delayed p Qr = g'\<close>
+                  \<open>spectroscopy_moves (Defender_Stable_Conj p Q Qr) g' =
+                    Some (\<lambda>e. Option.bind (if \<not> E 0 0 0 1 0 0 0 0 0 \<le> e then None else Some (e - E 0 0 0 1 0 0 0 0 0)) min1_6)\<close>
+              | (stability_check)
+                  \<open>Defender_Conj p {} = g'\<close>
+                  \<open>spectroscopy_moves (Defender_Stable_Conj p Q Qr) g' =
+                    Some (\<lambda>x. if \<not> E 0 0 0 1 0 0 0 0 1 \<le> x then None else Some (x - E 0 0 0 1 0 0 0 0 1))\<close>
+              using moves by auto
+            thus \<open>\<exists>e'. weight (Defender_Stable_Conj p Q Qr) g' e = Some e' \<and> attacker_wins e' g'\<close>
+            proof cases
+              case stable_answer
+              then show ?thesis
+                using clause_win \<open>Some e' = (subtract_fn 0 0 0 1 0 0 0 0 0) e\<close>
+                unfolding e_def
+                sledgehammer
+            next
+              case stable_revival
+              then show ?thesis using clause_win_revivals sorry
+            next
+              case stability_check
+              then show ?thesis
+                using defender_conj_empty_att_wins by (auto simp add: e_def)
+            qed
+          qed
+          hence \<open>attacker_wins e (Defender_Stable_Conj p Q Qr)\<close>
+            unfolding e_def
+            by (auto simp add: attacker_wins.Defense)
+          moreover have \<open>e \<le> expr_pr_inner (StableConj I \<psi>s)\<close>
+            using \<open>e' \<le> eu'\<close> eu'_characterization \<open>Some e' = (subtract_fn 0 0 0 1 0 0 0 0 0) e\<close> expr_lower case_assms(1) subset_form
+            unfolding e_def eu'_comp minus_energy_def leq_components
+            by (metis \<open>e' = e - E 0 0 0 1 0 0 0 0 0\<close> \<open>e' \<le> eu'\<close> e_def energy_subtraction_inequallity eu'_comp leq_components option.discI)
+         ultimately show \<open>attacker_wins (expr_pr_inner (StableConj I \<psi>s)) (Defender_Stable_Conj p Q Qr)\<close>
+            using win_a_upwards_closure by blast
         next
           case False
           then obtain \<psi>r where \<open>revivals = {\<psi>r}\<close>

--- a/Distinction_Implies_Winning_Budgets.thy
+++ b/Distinction_Implies_Winning_Budgets.thy
@@ -47,8 +47,8 @@ proof-
 
   moreover have \<open>attacker (Attacker_Immediate p {})\<close> by simp
   ultimately show ?thesis using attacker_wins.Attack[of \<open>Attacker_Immediate p {}\<close> _ \<open>expressiveness_price \<phi>\<close>]
-    using next_move0 next_move1
-    by (metis conj_win attacker_wins.Attack option.distinct(1) option.sel spectroscopy_defender.simps(4))
+    using next_move0 next_move1 attacker_wins_Ga_with_id_step conj_win
+    by fastforce
 qed
 
 text \<open>Next, we show the statement for the case that @{term \<open>Q \<noteq> {}\<close>}. Following the proof of
@@ -67,16 +67,18 @@ proof-
         \<and> (\<forall>\<Psi>_I \<Psi> p Q. \<chi> = Conj \<Psi>_I \<Psi> \<longrightarrow>
             Q \<noteq> {} \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q
             \<longrightarrow> attacker_wins (expr_pr_inner \<chi>) (Defender_Conj p Q))
-        \<and> (\<forall>\<Psi>_I \<Psi> p Q. \<chi> = StableConj \<Psi>_I \<Psi> \<longrightarrow>
-            Q \<noteq> {} \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q \<longrightarrow> (\<forall>q \<in> Q. \<nexists>q'. q \<mapsto> \<tau> q')
-            \<longrightarrow> attacker_wins (expr_pr_inner \<chi>) (Defender_Stable_Conj p Q))
+        \<and> (\<forall>\<Psi>_I \<Psi> p Q Qr. \<chi> = StableConj \<Psi>_I \<Psi> \<longrightarrow>
+            Q \<noteq> {} \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p (Q \<union> Qr) \<longrightarrow> (\<forall>q \<in> Q \<union> Qr. stable_state q)
+            \<longrightarrow> attacker_wins (expr_pr_inner \<chi>) (Defender_Stable_Conj p Q Qr))
         \<and> (\<forall>\<Psi>_I \<Psi> \<alpha> \<phi> p Q p' Q_\<alpha>. \<chi> = BranchConj \<alpha> \<phi> \<Psi>_I \<Psi> \<longrightarrow>
             hml_srbb_inner.distinguishes_from \<chi> p Q \<longrightarrow> p \<mapsto>a \<alpha> p' \<longrightarrow> p' \<Turnstile>SRBB \<phi> \<longrightarrow>
              Q_\<alpha> = Q - hml_srbb_inner.model_set (Obs \<alpha> \<phi>)
             \<longrightarrow> attacker_wins (expr_pr_inner \<chi>) (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>)))
       \<and>
         (\<forall>p q. hml_srbb_conj.distinguishes \<psi> p q
-               \<longrightarrow> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Clause p q))\<close>
+               \<longrightarrow> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Clause p q))
+        \<and> (\<forall>p q. hml_srbb_conj.distinguishes \<psi> p q
+               \<longrightarrow> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Stable_Clause p q))\<close>
   proof -
     fix \<phi> \<chi> \<psi>
     show \<open>(\<forall>Q p. Q \<noteq> {} \<longrightarrow> distinguishes_from \<phi> p Q
@@ -87,16 +89,18 @@ proof-
         \<and> (\<forall>\<Psi>_I \<Psi> p Q. \<chi> = Conj \<Psi>_I \<Psi> \<longrightarrow>
             Q \<noteq> {} \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q
             \<longrightarrow> attacker_wins (expr_pr_inner \<chi>) (Defender_Conj p Q))
-        \<and> (\<forall>\<Psi>_I \<Psi> p Q. \<chi> = StableConj \<Psi>_I \<Psi> \<longrightarrow>
-            Q \<noteq> {} \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q \<longrightarrow> (\<forall>q \<in> Q. \<nexists>q'. q \<mapsto> \<tau> q')
-            \<longrightarrow> attacker_wins (expr_pr_inner \<chi>) (Defender_Stable_Conj p Q))
+        \<and> (\<forall>\<Psi>_I \<Psi> p Q Qr. \<chi> = StableConj \<Psi>_I \<Psi> \<longrightarrow>
+            Q \<noteq> {} \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p (Q \<union> Qr) \<longrightarrow> (\<forall>q \<in> Q \<union> Qr. stable_state q)
+            \<longrightarrow> attacker_wins (expr_pr_inner \<chi>) (Defender_Stable_Conj p Q Qr))
         \<and> (\<forall>\<Psi>_I \<Psi> \<alpha> \<phi> p Q p' Q_\<alpha>. \<chi> = BranchConj \<alpha> \<phi> \<Psi>_I \<Psi> \<longrightarrow>
             hml_srbb_inner.distinguishes_from \<chi> p Q \<longrightarrow> p \<mapsto>a \<alpha> p' \<longrightarrow> p' \<Turnstile>SRBB \<phi> \<longrightarrow>
              Q_\<alpha> = Q - hml_srbb_inner.model_set (Obs \<alpha> \<phi>)
             \<longrightarrow> attacker_wins (expr_pr_inner \<chi>) (Defender_Branch p \<alpha> p' (Q - Q_\<alpha>) Q_\<alpha>)))
       \<and>
         (\<forall>p q. hml_srbb_conj.distinguishes \<psi> p q
-               \<longrightarrow> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Clause p q))\<close>
+               \<longrightarrow> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Clause p q))
+        \<and> (\<forall>p q. hml_srbb_conj.distinguishes \<psi> p q
+               \<longrightarrow> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Stable_Clause p q))\<close>
     proof (induct rule: hml_srbb_hml_srbb_inner_hml_srbb_conjunct.induct[of _ _ _ \<phi> \<chi> \<psi>])
       case TT
       then show ?case
@@ -197,33 +201,34 @@ proof-
           using hml_srbb_conj.distinguishes_def by simp
         hence \<open>\<forall>q\<in>Q. \<exists>i\<in>I. ((\<psi>s i) \<in> range \<psi>s) \<and> hml_srbb_conj.distinguishes (\<psi>s i) p q\<close> by blast
         hence \<open>\<forall>q\<in>Q. \<exists>i\<in>I. attacker_wins (expr_pr_conjunct (\<psi>s i)) (Attacker_Clause p q)\<close> using ImmConj by blast
-        hence a_clause_wina: \<open>\<forall>q\<in>Q. \<exists>i\<in>I. attacker_wins (expressiveness_price (ImmConj I \<psi>s) - E 0 0 1 0 1 0 0 0) (Attacker_Clause p q)\<close>
+        hence a_clause_wina: \<open>\<forall>q\<in>Q. \<exists>i\<in>I. attacker_wins (expressiveness_price (ImmConj I \<psi>s) - E 0 0 1 0 1 0 0 0 0) (Attacker_Clause p q)\<close>
           using expressiveness_price_ImmConj_geq_parts win_a_upwards_closure by fast
         from this \<open>Q \<noteq> {}\<close> have \<open>I \<noteq> {}\<close> by blast
         hence subtracts:
-          \<open>subtract_fn 0 0 1 0 1 0 0 0 (expressiveness_price (ImmConj I \<psi>s)) = Some (expressiveness_price (ImmConj I \<psi>s) - E 0 0 1 0 1 0 0 0)\<close>
-          \<open>subtract_fn 0 0 1 0 0 0 0 0 (expressiveness_price (ImmConj I \<psi>s) - E 0 0 0 0 1 0 0 0) = Some (expressiveness_price (ImmConj I \<psi>s) - E 0 0 1 0 1 0 0 0)\<close>
+          \<open>subtract_fn 0 0 1 0 1 0 0 0 0 (expressiveness_price (ImmConj I \<psi>s)) = Some (expressiveness_price (ImmConj I \<psi>s) - E 0 0 1 0 1 0 0 0 0)\<close>
+          \<open>subtract_fn 0 0 1 0 0 0 0 0 0 (expressiveness_price (ImmConj I \<psi>s) - E 0 0 0 0 1 0 0 0 0) = Some (expressiveness_price (ImmConj I \<psi>s) - E 0 0 1 0 1 0 0 0 0)\<close>
           by (simp add: \<open>I \<noteq> {}\<close>)+
         have def_conj: \<open>spectroscopy_defender (Defender_Conj p Q)\<close> by simp
         have \<open>spectroscopy_moves (Defender_Conj p Q) N \<noteq> None
               \<Longrightarrow> N = Attacker_Clause (attacker_state N) (defender_state N)\<close> for N
-          by (metis spectroscopy_moves.simps(34,35,36,38,64,74) spectroscopy_position.exhaust_sel)
+          by (cases N) auto
         hence move_kind: \<open>spectroscopy_moves (Defender_Conj p Q) N \<noteq> None \<Longrightarrow> \<exists>q\<in>Q. N = Attacker_Clause p q\<close> for N
           using conj_answer by metis
         hence update: \<open>\<And>g'. spectroscopy_moves (Defender_Conj p Q) g' \<noteq> None \<Longrightarrow>
-          weight (Defender_Conj p Q) g' = subtract_fn 0 0 1 0 0 0 0 0\<close>
+          weight (Defender_Conj p Q) g' = subtract_fn 0 0 1 0 0 0 0 0 0\<close>
           by fastforce
         hence move_wina: \<open>\<And>g'. spectroscopy_moves (Defender_Conj p Q) g' \<noteq> None \<Longrightarrow>
-          (subtract_fn 0 0 1 0 0 0 0 0) (expressiveness_price (ImmConj I \<psi>s) - E 0 0 0 0 1 0 0 0) = Some (expressiveness_price (ImmConj I \<psi>s) - E 0 0 1 0 1 0 0 0) \<and>
-          attacker_wins (expressiveness_price (ImmConj I \<psi>s) - E 0 0 1 0 1 0 0 0) g'\<close>
+          (subtract_fn 0 0 1 0 0 0 0 0 0) (expressiveness_price (ImmConj I \<psi>s) - E 0 0 0 0 1 0 0 0 0)
+               = Some (expressiveness_price (ImmConj I \<psi>s) - E 0 0 1 0 1 0 0 0 0) \<and>
+          attacker_wins (expressiveness_price (ImmConj I \<psi>s) - E 0 0 1 0 1 0 0 0 0) g'\<close>
           using move_kind a_clause_wina subtracts by blast
         from attacker_wins_Gd[OF def_conj] update move_wina have def_conj_wina:
-          \<open>attacker_wins (expressiveness_price (ImmConj I \<psi>s) - E 0 0 0 0 1 0 0 0) (Defender_Conj p Q)\<close>
+          \<open>attacker_wins (expressiveness_price (ImmConj I \<psi>s) - E 0 0 0 0 1 0 0 0 0) (Defender_Conj p Q)\<close>
           by blast
         have imm_to_conj: \<open>spectroscopy_moves (Attacker_Immediate p Q) (Defender_Conj p Q) \<noteq> None\<close>
           by (simp add: \<open>Q \<noteq> {}\<close>)
         have imm_to_conj_wgt: \<open>weight (Attacker_Immediate p Q) (Defender_Conj p Q) (expressiveness_price (ImmConj I \<psi>s))
-          = Some (expressiveness_price (ImmConj I \<psi>s) - E 0 0 0 0 1 0 0 0)\<close>
+          = Some (expressiveness_price (ImmConj I \<psi>s) - E 0 0 0 0 1 0 0 0 0)\<close>
           using \<open>Q \<noteq> {}\<close> leq_components subtracts(1) by force
         from Attack[OF _ imm_to_conj imm_to_conj_wgt] def_conj_wina
         show \<open>attacker_wins (expressiveness_price (ImmConj I \<psi>s)) (Attacker_Immediate p Q)\<close>
@@ -281,11 +286,11 @@ proof-
           wina: \<open>attacker_wins (expressiveness_price \<phi>) (Attacker_Immediate p' Q')\<close> by blast
         have attacker: \<open>attacker (Attacker_Delayed p Q)\<close> by simp
         have \<open>spectroscopy_moves (Attacker_Delayed p Q) (Attacker_Immediate p' Q') =
-              (if (\<exists>a. p \<mapsto>a a p' \<and> Q \<mapsto>aS a Q') then Some (subtract_fn 1 0 0 0 0 0 0 0) else None)\<close>
+              (if (\<exists>a. p \<mapsto>a a p' \<and> Q \<mapsto>aS a Q') then Some (subtract_fn 1 0 0 0 0 0 0 0 0) else None)\<close>
           for p Q p' Q' by simp
         from this[of p Q p' Q'] have
           \<open>spectroscopy_moves (Attacker_Delayed p Q) (Attacker_Immediate p' Q') =
-               Some (subtract_fn 1 0 0 0 0 0 0 0)\<close> using p'_Q' by auto
+               Some (subtract_fn 1 0 0 0 0 0 0 0 0)\<close> using p'_Q' by auto
         with expr_obs_phi[of \<alpha> \<phi>] show
           \<open>attacker_wins (expr_pr_inner (hml_srbb_inner.Obs \<alpha> \<phi>)) (Attacker_Delayed p Q)\<close>
           using Attack[OF attacker _ _ wina]
@@ -323,6 +328,7 @@ proof-
           (Sup (st_conj_depth  ` (expr_pr_conjunct ` (\<psi>qs ` Q))))
           (Sup (imm_conj_depth  ` (expr_pr_conjunct ` (\<psi>qs ` Q))))
           (Sup (pos_conjuncts   ` (expr_pr_conjunct ` (\<psi>qs ` Q))))
+          (Sup (pos_conjuncts_sec   ` (expr_pr_conjunct ` (\<psi>qs ` Q))))
           (Sup (neg_conjuncts ` (expr_pr_conjunct ` (\<psi>qs ` Q))))
           (Sup (neg_depth ` (expr_pr_conjunct ` (\<psi>qs ` Q))))\<close>
         from conjuncts_present have \<open>\<forall>q\<in>Q. (expr_pr_conjunct (\<psi>qs q)) \<le> e'\<close>
@@ -337,6 +343,7 @@ proof-
           (Sup (st_conj_depth  ` (expr_pr_conjunct ` (\<psi>s ` I))))
           (Sup (imm_conj_depth  ` (expr_pr_conjunct ` (\<psi>s ` I))))
           (Sup (pos_conjuncts   ` (expr_pr_conjunct ` (\<psi>s ` I))))
+          (Sup (pos_conjuncts_sec   ` (expr_pr_conjunct ` (\<psi>s ` I))))
           (Sup (neg_conjuncts ` (expr_pr_conjunct ` (\<psi>s ` I))))
           (Sup (neg_depth ` (expr_pr_conjunct ` (\<psi>s ` I))))\<close>
         have subset_form: \<open>\<psi>qs ` Q \<subseteq> \<psi>s ` I\<close>
@@ -350,37 +357,38 @@ proof-
           (st_conj_depth e')
           (imm_conj_depth e')
           (pos_conjuncts e')
+          (pos_conjuncts_sec e')
           (neg_conjuncts e')
           (neg_depth e')\<close>
-        have \<open>e' = e - (E 0 0 1 0 0 0 0 0)\<close> unfolding e_def e'_def by simp
-        hence \<open>Some e' = (subtract_fn 0 0 1 0 0 0 0 0) e\<close>
+        have \<open>e' = e - (E 0 0 1 0 0 0 0 0 0)\<close> unfolding e_def e'_def by simp
+        hence \<open>Some e' = (subtract_fn 0 0 1 0 0 0 0 0 0) e\<close>
           by (auto, smt (verit) add_increasing2 e_def energy.sel energy_leq_cases i0_lb le_numeral_extra(4))
-        have expr_lower: \<open>(E 0 0 1 0 0 0 0 0) \<le> expr_pr_inner (Conj I \<psi>s)\<close>
+        have expr_lower: \<open>(E 0 0 1 0 0 0 0 0 0) \<le> expr_pr_inner (Conj I \<psi>s)\<close>
           using case_assms(1) subset_form by auto
-        have eu'_comp: \<open>eu' = (expr_pr_inner (Conj I \<psi>s)) - (E 0 0 1 0 0 0 0 0)\<close>
+        have eu'_comp: \<open>eu' = (expr_pr_inner (Conj I \<psi>s)) - (E 0 0 1 0 0 0 0 0 0)\<close>
           unfolding eu'_def
           by (auto simp add: bot_enat_def image_image)
-        with expr_lower have eu'_characterization: \<open>Some eu' = (subtract_fn 0 0 1 0 0 0 0 0) (expr_pr_inner (Conj I \<psi>s))\<close>
+        with expr_lower have eu'_characterization: \<open>Some eu' = (subtract_fn 0 0 1 0 0 0 0 0 0) (expr_pr_inner (Conj I \<psi>s))\<close>
           by presburger
         have \<open>\<forall>g'. spectroscopy_moves (Defender_Conj p Q) g' \<noteq> None
-        \<longrightarrow> (\<exists>q\<in>Q. (Attacker_Clause p q) = g') \<and> spectroscopy_moves (Defender_Conj p Q) g' = Some (subtract_fn 0 0 1 0 0 0 0 0)\<close>
+        \<longrightarrow> (\<exists>q\<in>Q. (Attacker_Clause p q) = g') \<and> spectroscopy_moves (Defender_Conj p Q) g' = Some (subtract_fn 0 0 1 0 0 0 0 0 0)\<close>
         proof clarify
           fix g' upd
           assume upd_def: \<open>spectroscopy_moves (Defender_Conj p Q) g' = Some upd\<close>
-          hence \<open>\<And>px q. g' = Attacker_Clause px q \<Longrightarrow> p = px \<and> q \<in> Q \<and> upd = (subtract_fn 0 0 1 0 0 0 0 0)\<close>
+          hence \<open>\<And>px q. g' = Attacker_Clause px q \<Longrightarrow> p = px \<and> q \<in> Q \<and> upd = (subtract_fn 0 0 1 0 0 0 0 0 0)\<close>
             by (metis (mono_tags, lifting) local.conj_answer option.sel option.simps(3))
-          with upd_def show \<open>(\<exists>q\<in>Q. Attacker_Clause p q = g') \<and> spectroscopy_moves (Defender_Conj p Q) g' = Some (subtract_fn 0 0 1 0 0 0 0 0)\<close>
+          with upd_def show \<open>(\<exists>q\<in>Q. Attacker_Clause p q = g') \<and> spectroscopy_moves (Defender_Conj p Q) g' = Some (subtract_fn 0 0 1 0 0 0 0 0 0)\<close>
             by (cases g', auto)
         qed
         hence \<open>\<forall>g'. spectroscopy_moves (Defender_Conj p Q) g' \<noteq> None
           \<longrightarrow> (\<exists>e'. (the (spectroscopy_moves (Defender_Conj p Q) g')) e = Some e' \<and> attacker_wins e' g')\<close>
           unfolding e_def
-          using clause_win \<open>Some e' = (subtract_fn 0 0 1 0 0 0 0 0) e\<close> e_def by force
+          using clause_win \<open>Some e' = (subtract_fn 0 0 1 0 0 0 0 0 0) e\<close> e_def by force
         hence \<open>attacker_wins e (Defender_Conj p Q)\<close>
           unfolding e_def using attacker_wins.Defense
           by auto
         moreover have \<open>e \<le> expr_pr_inner (Conj I \<psi>s)\<close>
-          using \<open>e' \<le> eu'\<close> eu'_characterization \<open>Some e' = (subtract_fn 0 0 1 0 0 0 0 0) e\<close> expr_lower case_assms(1) subset_form
+          using \<open>e' \<le> eu'\<close> eu'_characterization \<open>Some e' = (subtract_fn 0 0 1 0 0 0 0 0 0) e\<close> expr_lower case_assms(1) subset_form
           unfolding e_def
           by (smt (verit, ccfv_threshold) eu'_comp add_diff_cancel_enat
               add_mono_thms_linordered_semiring(1) enat.simps(3) enat_defs(2) energy.sel
@@ -397,53 +405,54 @@ proof-
         assume
           \<open>Q \<noteq> {}\<close>
           \<open>hml_srbb_inner.distinguishes_from (hml_srbb_inner.Conj I \<psi>s) p Q\<close>
-        hence \<open>attacker_wins (expr_pr_inner (hml_srbb_inner.Conj I \<psi>s)) (Defender_Conj p Q)\<close>
+        hence att_win: \<open>attacker_wins (expr_pr_inner (hml_srbb_inner.Conj I \<psi>s)) (Defender_Conj p Q)\<close>
           using main_case by blast
         moreover have \<open>spectroscopy_moves (Attacker_Delayed p Q) (Defender_Conj p Q) = Some Some\<close>
           by auto
         ultimately show \<open>attacker_wins (expr_pr_inner (hml_srbb_inner.Conj I \<psi>s)) (Attacker_Delayed p Q)\<close>
-          by (metis attacker_wins_Ga_with_id_step option.discI option.sel spectroscopy_defender.simps(4))
+          using attacker_wins_Ga_with_id_step[OF att_win] by auto
       qed
       ultimately show ?case by fastforce
     next
       case (StableConj I \<psi>s)
-      \<comment>\<open>The following proof is virtually the same as for \<open>Conj I \<psi>s\<close>\<close>
-      have main_case: \<open>(\<forall>\<Psi>_I \<Psi> p Q. StableConj I \<psi>s = StableConj \<Psi>_I \<Psi> \<longrightarrow>
-             Q \<noteq> {} \<longrightarrow> hml_srbb_inner.distinguishes_from (StableConj I \<psi>s) p Q \<longrightarrow> (\<forall>q\<in>Q. \<nexists>q'. q \<mapsto>\<tau> q')
-             \<longrightarrow> attacker_wins (expr_pr_inner (StableConj I \<psi>s)) (Defender_Stable_Conj p Q))\<close>
+      have main_case: \<open>\<forall>\<Psi>_I \<Psi> p Q Qr. Q \<noteq> {} \<longrightarrow>
+           hml_srbb_inner.distinguishes_from (StableConj I \<psi>s) p (Q \<union> Qr) \<longrightarrow>
+           (\<forall>q\<in>Q \<union> Qr. stable_state q) \<longrightarrow> attacker_wins (expr_pr_inner (StableConj I \<psi>s)) (Defender_Stable_Conj p Q Qr)\<close>
       proof clarify
-        fix p Q
+        fix p Q Qr
         assume case_assms:
           \<open>Q \<noteq> {}\<close>
-          \<open>hml_srbb_inner.distinguishes_from (StableConj I \<psi>s) p Q\<close>
-          \<open>\<forall>q\<in>Q. \<nexists>q'. q \<mapsto>\<tau> q'\<close>
-        hence distinctions: \<open>\<forall>q\<in>Q. \<exists>i\<in>I. hml_srbb_conj.distinguishes (\<psi>s i) p q\<close>
-          by (metis hml_srbb_conj.distinguishes_def hml_srbb_inner.distinguishes_from_def hml_srbb_inner_models.simps(3))
-        hence inductive_wins: \<open>\<forall>q\<in>Q. \<exists>i\<in>I. hml_srbb_conj.distinguishes (\<psi>s i) p q
-            \<and> attacker_wins (expr_pr_conjunct (\<psi>s i)) (Attacker_Clause p q)\<close>
+          \<open>hml_srbb_inner.distinguishes_from (StableConj I \<psi>s) p (Q \<union> Qr)\<close>
+          \<open>\<forall>q\<in>Q\<union>Qr. stable_state q\<close>
+          \<open>attacker_wins (expr_pr_inner (StableConj I \<psi>s)) (Defender_Stable_Conj p Q Qr)\<close>
+        hence distinctions: \<open>\<forall>q\<in>Q\<union>Qr. \<exists>i\<in>I. hml_srbb_conj.distinguishes (\<psi>s i) p q\<close>
+          by simp
+        hence inductive_wins: \<open>\<forall>q\<in>Q\<union>Qr. \<exists>i\<in>I. hml_srbb_conj.distinguishes (\<psi>s i) p q
+            \<and> attacker_wins (expr_pr_conjunct (\<psi>s i)) (Attacker_Stable_Clause p q)\<close>
           using StableConj by blast
         define \<psi>qs where
           \<open>\<psi>qs \<equiv> \<lambda>q. (SOME \<psi>. \<exists>i\<in>I. \<psi> = \<psi>s i \<and>  hml_srbb_conj.distinguishes \<psi> p q
-            \<and> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Clause p q))\<close>
+            \<and> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Stable_Clause p q))\<close>
         with inductive_wins someI have \<psi>qs_spec:
-          \<open>\<forall>q\<in>Q. \<exists>i\<in>I. \<psi>qs q = \<psi>s i \<and> hml_srbb_conj.distinguishes (\<psi>qs q ) p q
-            \<and> attacker_wins (expr_pr_conjunct (\<psi>qs q)) (Attacker_Clause p q)\<close>
+          \<open>\<forall>q\<in>Q\<union>Qr. \<exists>i\<in>I. \<psi>qs q = \<psi>s i \<and> hml_srbb_conj.distinguishes (\<psi>qs q ) p q
+            \<and> attacker_wins (expr_pr_conjunct (\<psi>qs q)) (Attacker_Stable_Clause p q)\<close>
           by (smt (verit))
         have conjuncts_present: \<open>\<forall>q\<in>Q. expr_pr_conjunct (\<psi>qs q) \<in> expr_pr_conjunct ` (\<psi>qs ` Q)\<close>
           using \<open>Q \<noteq> {}\<close> by blast
         define e' where \<open>e' = E
-          (Sup (modal_depth   ` (expr_pr_conjunct ` (\<psi>qs ` Q))))
-          (Sup (br_conj_depth   ` (expr_pr_conjunct ` (\<psi>qs ` Q))))
-          (Sup (conj_depth ` (expr_pr_conjunct ` (\<psi>qs ` Q))))
-          (Sup (st_conj_depth  ` (expr_pr_conjunct ` (\<psi>qs ` Q))))
-          (Sup (imm_conj_depth  ` (expr_pr_conjunct ` (\<psi>qs ` Q))))
-          (Sup (pos_conjuncts   ` (expr_pr_conjunct ` (\<psi>qs ` Q))))
-          (Sup (neg_conjuncts ` (expr_pr_conjunct ` (\<psi>qs ` Q))))
-          (Sup (neg_depth ` (expr_pr_conjunct ` (\<psi>qs ` Q))))\<close>
-        from conjuncts_present have \<open>\<forall>q\<in>Q. (expr_pr_conjunct (\<psi>qs q)) \<le> e'\<close> unfolding e'_def
-          by (smt (verit, best) SUP_upper energy.sel energy.simps(3) energy_leq_cases image_iff)
+          (Sup (modal_depth   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup (br_conj_depth   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup (conj_depth ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup (st_conj_depth  ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup (imm_conj_depth  ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup (pos_conjuncts   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup (pos_conjuncts_sec   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup (neg_conjuncts ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup ({1} \<union> neg_depth ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))\<close>
+        from conjuncts_present have \<open>\<forall>q\<in>Q\<union>Qr. (expr_pr_conjunct (\<psi>qs q)) \<le> e'\<close> unfolding e'_def
+          by (smt (z3) Sup_upper UnI2 energy.sel image_insert insert_iff leq_components mk_disjoint_insert)
         with \<psi>qs_spec win_a_upwards_closure
-          have clause_win: \<open>\<forall>q\<in>Q. attacker_wins e' (Attacker_Clause p q)\<close> by blast
+          have clause_win: \<open>\<forall>q\<in>Q. attacker_wins e' (Attacker_Stable_Clause p q)\<close> by blast
         define eu' where \<open>eu' = E
           (Sup (modal_depth   ` (expr_pr_conjunct ` (\<psi>s ` I))))
           (Sup (br_conj_depth   ` (expr_pr_conjunct ` (\<psi>s ` I))))
@@ -451,12 +460,17 @@ proof-
           (Sup (st_conj_depth  ` (expr_pr_conjunct ` (\<psi>s ` I))))
           (Sup (imm_conj_depth  ` (expr_pr_conjunct ` (\<psi>s ` I))))
           (Sup (pos_conjuncts   ` (expr_pr_conjunct ` (\<psi>s ` I))))
+          (Sup (pos_conjuncts_sec   ` (expr_pr_conjunct ` (\<psi>s ` I))))
           (Sup (neg_conjuncts ` (expr_pr_conjunct ` (\<psi>s ` I))))
-          (Sup (neg_depth ` (expr_pr_conjunct ` (\<psi>s ` I))))\<close>
-        have subset_form: \<open>\<psi>qs ` Q \<subseteq> \<psi>s ` I\<close>
+          (Sup ({1} \<union> neg_depth ` (expr_pr_conjunct ` (\<psi>s ` I))))\<close>
+        have subset_form: \<open>\<psi>qs ` (Q\<union>Qr) \<subseteq> \<psi>s ` I\<close>
           using \<psi>qs_spec by fastforce
+        \<comment> \<open>TODO: encode this computation\<close>
+        term \<open>Sup (((\<lambda>\<psi>. case \<psi> of (Pos \<chi>) \<Rightarrow> modal_depth_srbb_inner \<chi> | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct \<psi>) \<circ> \<psi>s)
+          ` (I - (revival_conjunct_index I \<psi>s)))\<close>
+
         hence \<open>e' \<le> eu'\<close> unfolding e'_def eu'_def
-          by (simp add: Sup_subset_mono image_mono)
+          by (simp add: Sup_subset_mono image_mono sup.coboundedI2)
         define e where \<open>e = E
           (modal_depth e')
           (br_conj_depth e')
@@ -464,15 +478,29 @@ proof-
           (1 + st_conj_depth e')
           (imm_conj_depth e')
           (pos_conjuncts e')
+          (pos_conjuncts_sec e')
           (neg_conjuncts e')
-          (neg_depth e')\<close>
-        have \<open>e' = e - (E 0 0 0 1 0 0 0 0)\<close> unfolding e_def e'_def by auto
-        hence \<open>Some e' = (subtract_fn 0 0 0 1 0 0 0 0) e\<close>
+          (sup 1 (neg_depth e'))\<close>
+        have \<open>e' = e - (E 0 0 0 1 0 0 0 0 0)\<close> unfolding e_def e'_def by auto
+        hence \<open>Some e' = (subtract_fn 0 0 0 1 0 0 0 0 0) e\<close>
           by (metis e_def energy.sel energy_leq_cases i0_lb le_iff_add)
-        have expr_lower: \<open>(E 0 0 0 1 0 0 0 0) \<le> expr_pr_inner (StableConj I \<psi>s)\<close>
+        have expr_lower: \<open>(E 0 0 0 1 0 0 0 0 0) \<le> expr_pr_inner (StableConj I \<psi>s)\<close>
           using case_assms(1) subset_form by force
-        have eu'_comp: \<open>eu' = (expr_pr_inner (StableConj I \<psi>s)) - (E 0 0 0 1 0 0 0 0)\<close>
+        have eu'_comp: \<open>eu' = (expr_pr_inner (StableConj I \<psi>s)) - (E 0 0 0 1 0 0 0 0 0)\<close>
           unfolding eu'_def using energy.sel
+          apply (auto simp add: bot_enat_def)
+          apply (metis (no_types, lifting) SUP_cong energy.sel image_image)
+          apply (metis (no_types, lifting) SUP_cong energy.sel image_image)
+          apply (metis (no_types, lifting) SUP_cong energy.sel image_image)
+          apply (metis (no_types, lifting) SUP_cong energy.sel image_image)
+          apply (metis (no_types, lifting) SUP_cong energy.sel image_image)
+             apply (metis (no_types, lifting) SUP_cong energy.sel image_image)
+          defer
+            apply (metis (no_types, lifting) SUP_cong energy.sel image_image)
+          apply (metis (no_types, lifting) energy.sel(9) image_cong image_image)
+          sledgehammer
+          apply (metis (no_types, lifting) SUP_cong energy.sel image_image)
+          apply (metis (no_types, lifting) SUP_cong image_image)
           by (auto simp add: bot_enat_def, (metis (no_types, lifting) SUP_cong image_image)+)
         with expr_lower have eu'_characterization: \<open>Some eu' = (subtract_fn 0 0 0 1 0 0 0 0) (expr_pr_inner (StableConj I \<psi>s))\<close>
           by presburger

--- a/Distinction_Implies_Winning_Budgets.thy
+++ b/Distinction_Implies_Winning_Budgets.thy
@@ -79,6 +79,7 @@ proof-
                \<longrightarrow> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Clause p q))
         \<and> (\<forall>p q. hml_srbb_conj.distinguishes \<psi> p q
                \<longrightarrow> attacker_wins (expr_pr_conjunct \<psi>) (Attacker_Stable_Clause p q))\<close>
+    \<comment> \<open>Likely, I should add another induction hypothesis to cater for conjuncts that distinguish from sets ... ?\<close>
   proof -
     fix \<phi> \<chi> \<psi>
     show \<open>(\<forall>Q p. Q \<noteq> {} \<longrightarrow> distinguishes_from \<phi> p Q
@@ -424,7 +425,6 @@ proof-
           \<open>Q \<noteq> {}\<close>
           \<open>hml_srbb_inner.distinguishes_from (StableConj I \<psi>s) p (Q \<union> Qr)\<close>
           \<open>\<forall>q\<in>Q\<union>Qr. stable_state q\<close>
-          \<open>attacker_wins (expr_pr_inner (StableConj I \<psi>s)) (Defender_Stable_Conj p Q Qr)\<close>
         hence distinctions: \<open>\<forall>q\<in>Q\<union>Qr. \<exists>i\<in>I. hml_srbb_conj.distinguishes (\<psi>s i) p q\<close>
           by simp
         hence inductive_wins: \<open>\<forall>q\<in>Q\<union>Qr. \<exists>i\<in>I. hml_srbb_conj.distinguishes (\<psi>s i) p q
@@ -437,6 +437,21 @@ proof-
           \<open>\<forall>q\<in>Q\<union>Qr. \<exists>i\<in>I. \<psi>qs q = \<psi>s i \<and> hml_srbb_conj.distinguishes (\<psi>qs q ) p q
             \<and> attacker_wins (expr_pr_conjunct (\<psi>qs q)) (Attacker_Stable_Clause p q)\<close>
           by (smt (verit))
+        define revivals where \<open>revivals \<equiv> revival_conjunct_index I \<psi>s\<close>
+        show \<open>attacker_wins (expr_pr_inner (StableConj I \<psi>s)) (Defender_Stable_Conj p Q Qr)\<close>
+        proof (cases \<open>revivals = {}\<close>)
+          case True
+          then show ?thesis sorry
+        next
+          case False
+          then obtain \<psi>r where \<open>revivals = {\<psi>r}\<close>
+            unfolding revivals_def revival_conjunct_index_def empty_iff
+            by (metis (no_types, lifting))
+
+          then show ?thesis sorry
+        qed
+
+
         have conjuncts_present: \<open>\<forall>q\<in>Q. expr_pr_conjunct (\<psi>qs q) \<in> expr_pr_conjunct ` (\<psi>qs ` Q)\<close>
           using \<open>Q \<noteq> {}\<close> by blast
         define e' where \<open>e' = E
@@ -446,7 +461,8 @@ proof-
           (Sup (st_conj_depth  ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
           (Sup (imm_conj_depth  ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
           (Sup (pos_conjuncts   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
-          (Sup (pos_conjuncts_sec   ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
+          (Sup (((\<lambda>\<psi>. case \<psi> of (Pos \<chi>) \<Rightarrow> modal_depth_srbb_inner \<chi> | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct \<psi>) \<circ> \<psi>qs)
+            ` ((Q\<union>Qr) - (revival_conjunct_index (Q\<union>Qr) \<psi>qs))))
           (Sup (neg_conjuncts ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))
           (Sup ({1} \<union> neg_depth ` (expr_pr_conjunct ` (\<psi>qs ` (Q\<union>Qr)))))\<close>
         from conjuncts_present have \<open>\<forall>q\<in>Q\<union>Qr. (expr_pr_conjunct (\<psi>qs q)) \<le> e'\<close> unfolding e'_def
@@ -460,7 +476,8 @@ proof-
           (Sup (st_conj_depth  ` (expr_pr_conjunct ` (\<psi>s ` I))))
           (Sup (imm_conj_depth  ` (expr_pr_conjunct ` (\<psi>s ` I))))
           (Sup (pos_conjuncts   ` (expr_pr_conjunct ` (\<psi>s ` I))))
-          (Sup (pos_conjuncts_sec   ` (expr_pr_conjunct ` (\<psi>s ` I))))
+          (Sup (((\<lambda>\<psi>. case \<psi> of (Pos \<chi>) \<Rightarrow> modal_depth_srbb_inner \<chi> | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct \<psi>) \<circ> \<psi>s)
+          ` (I - (revival_conjunct_index I \<psi>s))))
           (Sup (neg_conjuncts ` (expr_pr_conjunct ` (\<psi>s ` I))))
           (Sup ({1} \<union> neg_depth ` (expr_pr_conjunct ` (\<psi>s ` I))))\<close>
         have subset_form: \<open>\<psi>qs ` (Q\<union>Qr) \<subseteq> \<psi>s ` I\<close>

--- a/Energy.thy
+++ b/Energy.thy
@@ -163,13 +163,15 @@ text \<open>We also define abbreviations for performing subtraction.\<close>
 abbreviation \<open>subtract_fn a b c d e f g h i \<equiv>
   (\<lambda>x. if somewhere_larger x (E a b c d e f g h i) then None else Some (x - (E a b c d e f g h i)))\<close>
 
-abbreviation \<open>subtract a b c d e f g h \<equiv> Some (subtract_fn a b c d e f g h)\<close>
+abbreviation \<open>subtract a b c d e f g h i \<equiv> Some (subtract_fn a b c d e f g h i)\<close>
 
 subsection \<open>Minimum Updates\<close>
-text \<open>Next, we define two energy updates that replace the first component with the minimum of two other components.\<close>
+
 definition \<open>min1_6 e \<equiv> case e of E a b c d e f g h i \<Rightarrow> Some (E (min a f) b c d e f g h i)\<close>
 definition \<open>min1_7 e \<equiv> case e of E a b c d e f g h i \<Rightarrow> Some (E (min a g) b c d e f g h i)\<close>
 definition \<open>min1_8 e \<equiv> case e of E a b c d e f g h i \<Rightarrow> Some (E (min a h) b c d e f g h i)\<close>
+
+definition \<open>min6_7 e \<equiv> case e of E a b c d e f g h i \<Rightarrow> Some (E a b c d e f (min g f) h i)\<close>
 
 
 text \<open>lift order to options\<close>
@@ -249,9 +251,21 @@ lemma min_1_8_simps[simp]:
         \<open>neg_depth (the (min1_8 e)) = neg_depth e\<close>
   unfolding min1_8_def by (simp_all add: energy.case_eq_if)
 
+lemma min_6_7_simps[simp]:
+  shows \<open>modal_depth (the (min6_7 e)) = modal_depth e\<close>
+        \<open>br_conj_depth (the (min6_7 e)) = br_conj_depth e\<close>
+        \<open>conj_depth (the (min6_7 e)) = conj_depth e\<close>
+        \<open>st_conj_depth (the (min6_7 e)) = st_conj_depth e\<close>
+        \<open>imm_conj_depth (the (min6_7 e)) = imm_conj_depth e\<close>
+        \<open>pos_conjuncts (the (min6_7 e)) =  pos_conjuncts e\<close>
+        \<open>pos_conjuncts_sec (the (min6_7 e)) = min (pos_conjuncts e) (pos_conjuncts_sec e)\<close>
+        \<open>neg_conjuncts (the (min6_7 e)) = neg_conjuncts e\<close>
+        \<open>neg_depth (the (min6_7 e)) = neg_depth e\<close>
+  unfolding min6_7_def by (simp_all add: energy.case_eq_if min.commute)
+
 lemma min_some:
-  shows \<open>min1_6 e \<noteq> None\<close>  \<open>min1_7 e \<noteq> None\<close>  \<open>min1_8 e \<noteq> None\<close>
-  unfolding min1_6_def min1_7_def min1_8_def
+  shows \<open>min1_6 e \<noteq> None\<close>  \<open>min1_7 e \<noteq> None\<close>  \<open>min1_8 e \<noteq> None\<close>  \<open>min6_7 e \<noteq> None\<close>
+  unfolding min1_6_def min1_7_def min1_8_def min6_7_def
   using energy.case_eq_if by blast+
 
 lemma mono_min_1_6:
@@ -309,6 +323,15 @@ lemma min_1_6_subtr_simp:
     = (if br_conj_depth e = 0 \<or> conj_depth e = 0 then None
         else Some (E (min (modal_depth e) (pos_conjuncts e)) (br_conj_depth e - 1) (conj_depth e - 1) (st_conj_depth e) (imm_conj_depth e) (pos_conjuncts e) (pos_conjuncts_sec e) (neg_conjuncts e) (neg_depth e)))\<close>
   by (auto simp add: min1_6_def ileI1 one_eSuc)
+
+lemma min_6_7_subtr_simp:
+  shows \<open>(Option.bind ((subtract_fn 0 0 0 1 0 0 0 0 0) e) min6_7) = (if st_conj_depth e = 0 then None else Some (E (modal_depth e) (br_conj_depth e) (conj_depth e) (st_conj_depth e - 1) (imm_conj_depth e) (pos_conjuncts e) (min (pos_conjuncts_sec e) (pos_conjuncts e)) (neg_conjuncts e) (neg_depth e)))\<close>
+  by (auto simp add: min6_7_def ileI1 one_eSuc)
+
+lemma min_6_7_subtr_mono:
+  \<open>mono (\<lambda>e. Option.bind ((subtract_fn 0 0 0 1 0 0 0 0 0) e) min6_7)\<close>
+  unfolding min_6_7_subtr_simp mono_def
+  by (auto simp add: min.coboundedI1  min.coboundedI2 enat_diff_mono)
 
 instantiation energy :: Sup
 begin

--- a/Energy.thy
+++ b/Energy.thy
@@ -43,6 +43,12 @@ lemma leq_components[simp]:
                      pos_conjuncts_sec e1 \<le> pos_conjuncts_sec e2 \<and> neg_conjuncts e1 \<le> neg_conjuncts e2 \<and> neg_depth e1 \<le> neg_depth e2)\<close>
   unfolding less_eq_energy_def by (simp add: energy.case_eq_if)
 
+
+
+lemma leq_components_constr[simp]:
+  shows \<open>E a1 b1 c1 d1 e1 f1 g1 h1 i1 \<le> E a2 b2 c2 d2 e2 f2 g2 h2 i2 \<equiv> a1 \<le> a2 \<and> b1 \<le> b2 \<and> c1 \<le> c2 \<and> d1 \<le> d2 \<and> e1 \<le> e2 \<and> f1 \<le> f2 \<and> g1 \<le> g2 \<and> h1 \<le> h2 \<and> i1 \<le> i2\<close>
+  unfolding less_eq_energy_def by simp
+
 lemma energy_leq_cases:
   assumes \<open>modal_depth e1 \<le> modal_depth e2\<close> \<open>br_conj_depth e1 \<le> br_conj_depth e2\<close> \<open>conj_depth e1 \<le> conj_depth e2\<close>
           \<open>st_conj_depth e1 \<le> st_conj_depth e2\<close> \<open>imm_conj_depth e1 \<le> imm_conj_depth e2\<close> \<open>pos_conjuncts e1 \<le> pos_conjuncts e2\<close>
@@ -158,6 +164,17 @@ lemma mono_subtract:
   assumes \<open>x \<le> x'\<close>
   shows \<open>(\<lambda>x. x - (E a b c d e f g h i)) x \<le> (\<lambda>x. x - (E a b c d e f g h i)) x'\<close>
   using assms enat_diff_mono by force
+
+lemma energy_subtraction_inequallity:
+  fixes d::energy
+  assumes
+    \<open>d \<le> x\<close>
+    \<open>d \<le> x'\<close>
+    \<open>x - d \<le> x' - d\<close>
+  shows
+    \<open>x \<le> x'\<close>
+  using assms add_diff_cancel_enat enat_add_left_cancel_le le_iff_add
+  by (smt (z3) energy.sel leq_components minus_energy_def)
 
 text \<open>We also define abbreviations for performing subtraction.\<close>
 abbreviation \<open>subtract_fn a b c d e f g h i \<equiv>

--- a/Energy.thy
+++ b/Energy.thy
@@ -9,7 +9,7 @@ text \<open>Following the paper \cite[p. 5]{bisping2023lineartimebranchingtime},
       an energy @{text \<open>eneg\<close>} that represents negative energy. This allows us to
       express energy updates (cf. \cite[p. 8]{bisping2023lineartimebranchingtime}) as total functions\label{deviation:eneg}.\<close>
 datatype energy = E (modal_depth: \<open>enat\<close>) (br_conj_depth: \<open>enat\<close>) (conj_depth: \<open>enat\<close>) (st_conj_depth: \<open>enat\<close>)
-                    (imm_conj_depth: \<open>enat\<close>) (pos_conjuncts: \<open>enat\<close>) (neg_conjuncts: \<open>enat\<close>) (neg_depth: \<open>enat\<close>)
+                    (imm_conj_depth: \<open>enat\<close>) (pos_conjuncts: \<open>enat\<close>) (pos_conjuncts_sec: \<open>enat\<close>) (neg_conjuncts: \<open>enat\<close>) (neg_depth: \<open>enat\<close>)
 
 subsection \<open>Ordering Energies\<close>
 text \<open>In order to define subtraction on energies, we first lift the orderings
@@ -17,9 +17,9 @@ text \<open>In order to define subtraction on energies, we first lift the orderi
 instantiation energy :: order begin
 
 definition \<open>e1 \<le> e2 \<equiv>
-  (case e1 of E a1 b1 c1 d1 e1 f1 g1 h1 \<Rightarrow> (
-    case e2 of E a2 b2 c2 d2 e2 f2 g2 h2 \<Rightarrow>
-      (a1 \<le> a2 \<and> b1 \<le> b2 \<and> c1 \<le> c2 \<and> d1 \<le> d2 \<and> e1 \<le> e2 \<and> f1 \<le> f2 \<and> g1 \<le> g2 \<and> h1 \<le> h2)
+  (case e1 of E a1 b1 c1 d1 e1 f1 g1 h1 i1 \<Rightarrow> (
+    case e2 of E a2 b2 c2 d2 e2 f2 g2 h2 i2 \<Rightarrow>
+      (a1 \<le> a2 \<and> b1 \<le> b2 \<and> c1 \<le> c2 \<and> d1 \<le> d2 \<and> e1 \<le> e2 \<and> f1 \<le> f2 \<and> g1 \<le> g2 \<and> h1 \<le> h2 \<and> i1 \<le> i2)
     ))\<close>
 
 definition \<open>(x::energy) < y = (x \<le> y \<and> \<not> y \<le> x)\<close>
@@ -40,13 +40,13 @@ qed
 lemma leq_components[simp]:
   shows \<open>e1 \<le> e2 \<equiv> (modal_depth e1 \<le> modal_depth e2 \<and> br_conj_depth e1 \<le> br_conj_depth e2 \<and> conj_depth e1 \<le> conj_depth e2 \<and>
                      st_conj_depth e1 \<le> st_conj_depth e2 \<and> imm_conj_depth e1 \<le> imm_conj_depth e2 \<and> pos_conjuncts e1 \<le> pos_conjuncts e2 \<and>
-                     neg_conjuncts e1 \<le> neg_conjuncts e2 \<and> neg_depth e1 \<le> neg_depth e2)\<close>
+                     pos_conjuncts_sec e1 \<le> pos_conjuncts_sec e2 \<and> neg_conjuncts e1 \<le> neg_conjuncts e2 \<and> neg_depth e1 \<le> neg_depth e2)\<close>
   unfolding less_eq_energy_def by (simp add: energy.case_eq_if)
 
 lemma energy_leq_cases:
   assumes \<open>modal_depth e1 \<le> modal_depth e2\<close> \<open>br_conj_depth e1 \<le> br_conj_depth e2\<close> \<open>conj_depth e1 \<le> conj_depth e2\<close>
           \<open>st_conj_depth e1 \<le> st_conj_depth e2\<close> \<open>imm_conj_depth e1 \<le> imm_conj_depth e2\<close> \<open>pos_conjuncts e1 \<le> pos_conjuncts e2\<close>
-          \<open>neg_conjuncts e1 \<le> neg_conjuncts e2\<close> \<open>neg_depth e1 \<le> neg_depth e2\<close>
+          \<open>pos_conjuncts_sec e1 \<le> pos_conjuncts_sec e2\<close> \<open>neg_conjuncts e1 \<le> neg_conjuncts e2\<close> \<open>neg_depth e1 \<le> neg_depth e2\<close>
   shows \<open>e1 \<le> e2\<close> using assms unfolding leq_components by blast
 
 end
@@ -60,7 +60,8 @@ lemma somewhere_larger_eq:
   assumes \<open>somewhere_larger e1 e2\<close>
   shows \<open>modal_depth e1 < modal_depth e2 \<or> br_conj_depth e1 < br_conj_depth e2
          \<or> conj_depth e1 < conj_depth e2 \<or> st_conj_depth e1 < st_conj_depth e2 \<or> imm_conj_depth e1 < imm_conj_depth e2
-         \<or> pos_conjuncts e1 < pos_conjuncts e2 \<or> neg_conjuncts e1 < neg_conjuncts e2 \<or> neg_depth e1 < neg_depth e2\<close>
+         \<or> pos_conjuncts e1 < pos_conjuncts e2 \<or> pos_conjuncts_sec e1 < pos_conjuncts_sec e2 
+         \<or> neg_conjuncts e1 < neg_conjuncts e2 \<or> neg_depth e1 < neg_depth e2\<close>
   by (smt (z3) assms energy.case_eq_if less_eq_energy_def linorder_le_less_linear)
 
 subsection \<open>Subtracting Energies\<close>
@@ -77,6 +78,7 @@ definition minus_energy_def[simp]: \<open>e1 - e2 \<equiv> E
   ((st_conj_depth e1) - (st_conj_depth e2))
   ((imm_conj_depth e1) - (imm_conj_depth e2))
   ((pos_conjuncts e1) - (pos_conjuncts e2))
+  ((pos_conjuncts_sec e1) - (pos_conjuncts_sec e2))
   ((neg_conjuncts e1) - (neg_conjuncts e2))
   ((neg_depth e1) - (neg_depth e2))\<close>
 
@@ -87,30 +89,34 @@ end
 text \<open>Afterwards, we prove some lemmas to ease the manipulation of expressions
   using subtraction on energies.\<close>
 lemma energy_minus[simp]:
-  shows \<open>E a1 b1 c1 d1 e1 f1 g1 h1 - E a2 b2 c2 d2 e2 f2 g2 h2
+  shows \<open>E a1 b1 c1 d1 e1 f1 g1 h1 i1 - E a2 b2 c2 d2 e2 f2 g2 h2 i2
          = E (a1 - a2) (b1 - b2) (c1 - c2) (d1 - d2)
-             (e1 - e2) (f1 - f2) (g1 - g2) (h1 - h2)\<close>
+             (e1 - e2) (f1 - f2) (g1 - g2) (h1 - h2) (i1 - i2)\<close>
   unfolding minus_energy_def somewhere_larger_eq by simp
 
 lemma minus_component_leq:
   assumes \<open>s \<le> x\<close> \<open>x \<le> y\<close>
-  shows \<open>modal_depth (x - s) \<le> modal_depth (y - s)\<close> \<open>br_conj_depth (x - s) \<le> br_conj_depth (y - s)\<close>
-        \<open>conj_depth (x - s) \<le> conj_depth (y - s)\<close> \<open>st_conj_depth (x - s) \<le> st_conj_depth (y - s)\<close>
-        \<open>imm_conj_depth (x - s) \<le> imm_conj_depth (y - s)\<close> \<open>pos_conjuncts (x - s) \<le> pos_conjuncts (y -s)\<close>
-        \<open>neg_conjuncts (x - s) \<le> neg_conjuncts (y - s)\<close> \<open>neg_depth (x - s) \<le> neg_depth (y - s)\<close>
-proof-
+  shows
+    \<open>modal_depth (x - s) \<le> modal_depth (y - s)\<close> \<open>br_conj_depth (x - s) \<le> br_conj_depth (y - s)\<close>
+    \<open>conj_depth (x - s) \<le> conj_depth (y - s)\<close> \<open>st_conj_depth (x - s) \<le> st_conj_depth (y - s)\<close>
+    \<open>imm_conj_depth (x - s) \<le> imm_conj_depth (y - s)\<close> \<open>pos_conjuncts (x - s) \<le> pos_conjuncts (y - s)\<close>
+    \<open>pos_conjuncts_sec (x - s) \<le> pos_conjuncts_sec (y - s)\<close>
+    \<open>neg_conjuncts (x - s) \<le> neg_conjuncts (y - s)\<close> \<open>neg_depth (x - s) \<le> neg_depth (y - s)\<close>
+proof -
   from assms have \<open>s \<le> y\<close> by (simp del: leq_components)
   with assms leq_components have
     \<open>modal_depth (x - s) \<le> modal_depth (y - s) \<and> br_conj_depth (x - s) \<le> br_conj_depth (y - s) \<and>
     conj_depth (x - s) \<le> conj_depth (y - s) \<and> st_conj_depth (x - s) \<le> st_conj_depth (y - s) \<and>
-    imm_conj_depth (x - s) \<le> imm_conj_depth (y - s) \<and> pos_conjuncts (x - s) \<le> pos_conjuncts (y -s) \<and>
+    imm_conj_depth (x - s) \<le> imm_conj_depth (y - s) \<and> pos_conjuncts (x - s) \<le> pos_conjuncts (y - s) \<and>
+    pos_conjuncts_sec (x - s) \<le> pos_conjuncts_sec (y - s) \<and>
     neg_conjuncts (x - s) \<le> neg_conjuncts (y - s) \<and> neg_depth (x - s) \<le> neg_depth (y - s)\<close>
     by (smt (verit, del_insts) add_diff_cancel_enat enat_add_left_cancel_le energy.sel
         leD le_iff_add le_less minus_energy_def)+
   thus
     \<open>modal_depth (x - s) \<le> modal_depth (y - s)\<close> \<open>br_conj_depth (x - s) \<le> br_conj_depth (y - s)\<close>
     \<open>conj_depth (x - s) \<le> conj_depth (y - s)\<close> \<open>st_conj_depth (x - s) \<le> st_conj_depth (y - s)\<close>
-    \<open>imm_conj_depth (x - s) \<le> imm_conj_depth (y - s)\<close> \<open>pos_conjuncts (x - s) \<le> pos_conjuncts (y -s)\<close>
+    \<open>imm_conj_depth (x - s) \<le> imm_conj_depth (y - s)\<close> \<open>pos_conjuncts (x - s) \<le> pos_conjuncts (y - s)\<close>
+    \<open>pos_conjuncts_sec (x - s) \<le> pos_conjuncts_sec (y - s)\<close>
     \<open>neg_conjuncts (x - s) \<le> neg_conjuncts (y - s)\<close> \<open>neg_depth (x - s) \<le> neg_depth (y - s)\<close> by auto
 qed
 
@@ -150,19 +156,20 @@ lemma gets_smaller:
 
 lemma mono_subtract:
   assumes \<open>x \<le> x'\<close>
-  shows \<open>(\<lambda>x. x - (E a b c d e f g h)) x \<le> (\<lambda>x. x - (E a b c d e f g h)) x'\<close>
+  shows \<open>(\<lambda>x. x - (E a b c d e f g h i)) x \<le> (\<lambda>x. x - (E a b c d e f g h i)) x'\<close>
   using assms enat_diff_mono by force
 
 text \<open>We also define abbreviations for performing subtraction.\<close>
-abbreviation \<open>subtract_fn a b c d e f g h \<equiv>
-  (\<lambda>x. if somewhere_larger x (E a b c d e f g h) then None else Some (x - (E a b c d e f g h)))\<close>
+abbreviation \<open>subtract_fn a b c d e f g h i \<equiv>
+  (\<lambda>x. if somewhere_larger x (E a b c d e f g h i) then None else Some (x - (E a b c d e f g h i)))\<close>
 
 abbreviation \<open>subtract a b c d e f g h \<equiv> Some (subtract_fn a b c d e f g h)\<close>
 
 subsection \<open>Minimum Updates\<close>
 text \<open>Next, we define two energy updates that replace the first component with the minimum of two other components.\<close>
-definition \<open>min1_6 e \<equiv> case e of E a b c d e f g h \<Rightarrow> Some (E (min a f) b c d e f g h)\<close>
-definition \<open>min1_7 e \<equiv> case e of E a b c d e f g h \<Rightarrow> Some (E (min a g) b c d e f g h)\<close>
+definition \<open>min1_6 e \<equiv> case e of E a b c d e f g h i \<Rightarrow> Some (E (min a f) b c d e f g h i)\<close>
+definition \<open>min1_7 e \<equiv> case e of E a b c d e f g h i \<Rightarrow> Some (E (min a g) b c d e f g h i)\<close>
+definition \<open>min1_8 e \<equiv> case e of E a b c d e f g h i \<Rightarrow> Some (E (min a h) b c d e f g h i)\<close>
 
 
 text \<open>lift order to options\<close>
@@ -213,30 +220,39 @@ lemma min_1_6_simps[simp]:
         \<open>st_conj_depth (the (min1_6 e)) = st_conj_depth e\<close>
         \<open>imm_conj_depth (the (min1_6 e)) = imm_conj_depth e\<close>
         \<open>pos_conjuncts (the (min1_6 e)) = pos_conjuncts e\<close>
+        \<open>pos_conjuncts_sec (the (min1_6 e)) = pos_conjuncts_sec e\<close>
         \<open>neg_conjuncts (the (min1_6 e)) = neg_conjuncts e\<close>
         \<open>neg_depth (the (min1_6 e)) = neg_depth e\<close>
   unfolding min1_6_def by (simp_all add: energy.case_eq_if)
 
 lemma min_1_7_simps[simp]:
-  shows \<open>modal_depth (the (min1_7 e)) = min (modal_depth e) (neg_conjuncts e)\<close>
+  shows \<open>modal_depth (the (min1_7 e)) = min (modal_depth e) (pos_conjuncts_sec e)\<close>
         \<open>br_conj_depth (the (min1_7 e)) = br_conj_depth e\<close>
         \<open>conj_depth (the (min1_7 e)) = conj_depth e\<close>
         \<open>st_conj_depth (the (min1_7 e)) = st_conj_depth e\<close>
         \<open>imm_conj_depth (the (min1_7 e)) = imm_conj_depth e\<close>
         \<open>pos_conjuncts (the (min1_7 e)) = pos_conjuncts e\<close>
+        \<open>pos_conjuncts_sec (the (min1_7 e)) = pos_conjuncts_sec e\<close>
         \<open>neg_conjuncts (the (min1_7 e)) = neg_conjuncts e\<close>
         \<open>neg_depth (the (min1_7 e)) = neg_depth e\<close>
   unfolding min1_7_def by (simp_all add: energy.case_eq_if)
 
-lemma min_1_6_some:
-  shows \<open>min1_6 e \<noteq> None\<close>
-  unfolding min1_6_def
-  using energy.case_eq_if by blast
+lemma min_1_8_simps[simp]:
+  shows \<open>modal_depth (the (min1_8 e)) = min (modal_depth e) (neg_conjuncts e)\<close>
+        \<open>br_conj_depth (the (min1_8 e)) = br_conj_depth e\<close>
+        \<open>conj_depth (the (min1_8 e)) = conj_depth e\<close>
+        \<open>st_conj_depth (the (min1_8 e)) = st_conj_depth e\<close>
+        \<open>imm_conj_depth (the (min1_8 e)) = imm_conj_depth e\<close>
+        \<open>pos_conjuncts (the (min1_8 e)) = pos_conjuncts e\<close>
+        \<open>pos_conjuncts_sec (the (min1_8 e)) = pos_conjuncts_sec e\<close>
+        \<open>neg_conjuncts (the (min1_8 e)) = neg_conjuncts e\<close>
+        \<open>neg_depth (the (min1_8 e)) = neg_depth e\<close>
+  unfolding min1_8_def by (simp_all add: energy.case_eq_if)
 
-lemma min_1_7_some:
-  shows \<open>min1_7 e \<noteq> None\<close>
-  unfolding min1_7_def
-  using energy.case_eq_if by blast
+lemma min_some:
+  shows \<open>min1_6 e \<noteq> None\<close>  \<open>min1_7 e \<noteq> None\<close>  \<open>min1_8 e \<noteq> None\<close>
+  unfolding min1_6_def min1_7_def min1_8_def
+  using energy.case_eq_if by blast+
 
 lemma mono_min_1_6:
   shows \<open>mono (the \<circ> min1_6)\<close>
@@ -260,46 +276,45 @@ lemma gets_smaller_min_1_6:
   shows \<open>the (min1_6 x) \<le> x\<close>
   using min_1_6_simps min_less_iff_conj somewhere_larger_eq by fastforce
 
-
-lemma gets_smaller_min_1_7:
-  shows \<open>the (min1_7 x) \<le> x\<close>
+lemma gets_smaller_min_1_8:
+  shows \<open>the (min1_8 x) \<le> x\<close>
   using min_1_7_simps min_less_iff_conj somewhere_larger_eq by fastforce
 
-lemma min_1_7_lower_end:
-  assumes \<open>(Option.bind ((subtract_fn 0 0 0 0 0 0 0 1) e) min1_7) = None\<close>
+lemma min_1_8_lower_end:
+  assumes \<open>(Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8) = None\<close>
   shows \<open>neg_depth e = 0\<close>
   using assms
-  by (smt (verit) bind.bind_lunit energy.sel ileI1 leq_components min_1_7_some not_gr_zero one_eSuc zero_le)
+  by (smt (verit) bind.bind_lunit energy.sel ileI1 leq_components min_some not_gr_zero one_eSuc zero_le)
 
-lemma min_1_7_subtr_simp:
-  shows \<open>(Option.bind ((subtract_fn 0 0 0 0 0 0 0 1) e) min1_7)
+lemma min_1_8_subtr_simp:
+  shows \<open>(Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8)
     = (if neg_depth e = 0 then None
-        else Some (E (min (modal_depth e) (neg_conjuncts e)) (br_conj_depth e) (conj_depth e) (st_conj_depth e) (imm_conj_depth e) (pos_conjuncts e) (neg_conjuncts e) (neg_depth e - 1)))\<close>
-  using min_1_7_lower_end
-  by (auto simp add: min1_7_def)
+        else Some (E (min (modal_depth e) (neg_conjuncts e)) (br_conj_depth e) (conj_depth e) (st_conj_depth e) (imm_conj_depth e) (pos_conjuncts e) (pos_conjuncts_sec e) (neg_conjuncts e) (neg_depth e - 1)))\<close>
+  using min_1_8_lower_end
+  by (auto simp add: min1_8_def)
 
-lemma min_1_7_subtr_mono:
-  shows \<open>mono (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 1) e) min1_7)\<close>
+lemma min_1_8_subtr_mono:
+  shows \<open>mono (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8)\<close>
 proof
   fix e1 e2 :: energy
   assume \<open>e1 \<le> e2\<close>
-  thus \<open>(\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 1) e) min1_7) e1
-    \<le>  (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 1) e) min1_7) e2\<close>
-    unfolding min_1_7_subtr_simp
+  thus \<open>(\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8) e1
+    \<le>  (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8) e2\<close>
+    unfolding min_1_8_subtr_simp
     by (auto simp add: min.coboundedI1  min.coboundedI2 enat_diff_mono)
 qed
 
 lemma min_1_6_subtr_simp:
-  shows \<open>(Option.bind ((subtract_fn 0 1 1 0 0 0 0 0) e) min1_6)
+  shows \<open>(Option.bind ((subtract_fn 0 1 1 0 0 0 0 0 0) e) min1_6)
     = (if br_conj_depth e = 0 \<or> conj_depth e = 0 then None
-        else Some (E (min (modal_depth e) (pos_conjuncts e)) (br_conj_depth e - 1) (conj_depth e - 1) (st_conj_depth e) (imm_conj_depth e) (pos_conjuncts e) (neg_conjuncts e) (neg_depth e)))\<close>
+        else Some (E (min (modal_depth e) (pos_conjuncts e)) (br_conj_depth e - 1) (conj_depth e - 1) (st_conj_depth e) (imm_conj_depth e) (pos_conjuncts e) (pos_conjuncts_sec e) (neg_conjuncts e) (neg_depth e)))\<close>
   by (auto simp add: min1_6_def ileI1 one_eSuc)
 
 instantiation energy :: Sup
 begin
 
 definition \<open>Sup ee \<equiv> E (Sup (modal_depth ` ee)) (Sup (br_conj_depth ` ee )) (Sup (conj_depth ` ee)) (Sup (st_conj_depth ` ee))
-  (Sup (imm_conj_depth ` ee)) (Sup (pos_conjuncts ` ee)) (Sup (neg_conjuncts ` ee)) (Sup (neg_depth ` ee))\<close>
+  (Sup (imm_conj_depth ` ee)) (Sup (pos_conjuncts ` ee)) (Sup (pos_conjuncts_sec ` ee)) (Sup (neg_conjuncts ` ee)) (Sup (neg_depth ` ee))\<close>
 
 instance ..
 end

--- a/Eta_Bisimilarity.thy
+++ b/Eta_Bisimilarity.thy
@@ -58,23 +58,25 @@ lemma eta_bisimulated_silently_retained:
 
 subsection \<open>Logical Characterization of \<open>\<eta>\<close>-Bisimilarity through Expressiveness Price\<close>
 
+abbreviation \<open>e\<eta> \<equiv> E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 \<infinity> \<infinity>\<close>
+
 lemma logic_eta_bisim_invariant:
   assumes
     \<open>p0 ~\<eta> q0\<close>
-    \<open>\<phi> \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+    \<open>\<phi> \<in> \<O> e\<eta>\<close>
     \<open>p0 \<Turnstile>SRBB \<phi>\<close>
   shows \<open>q0 \<Turnstile>SRBB \<phi>\<close>
 proof -
   have \<open>\<And>\<phi> \<chi> \<psi>.
-    (\<forall>p q. p ~\<eta> q \<longrightarrow> \<phi> \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>) \<longrightarrow> p \<Turnstile>SRBB \<phi> \<longrightarrow> q \<Turnstile>SRBB \<phi>) \<and>
-    (\<forall>p q. p ~\<eta> q \<longrightarrow> \<chi> \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>) \<longrightarrow> hml_srbb_inner_models p \<chi> \<longrightarrow> (\<exists>q'. q \<Zsurj> q' \<and> hml_srbb_inner_models q' \<chi>)) \<and>
-    (\<forall>p q. p ~\<eta> q \<longrightarrow> \<psi> \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>) \<longrightarrow> hml_srbb_conjunct_models p \<psi> \<longrightarrow> hml_srbb_conjunct_models q \<psi>)\<close>
+    (\<forall>p q. p ~\<eta> q \<longrightarrow> \<phi> \<in> \<O> e\<eta> \<longrightarrow> p \<Turnstile>SRBB \<phi> \<longrightarrow> q \<Turnstile>SRBB \<phi>) \<and>
+    (\<forall>p q. p ~\<eta> q \<longrightarrow> \<chi> \<in> \<O>_inner e\<eta> \<longrightarrow> hml_srbb_inner_models p \<chi> \<longrightarrow> (\<exists>q'. q \<Zsurj> q' \<and> hml_srbb_inner_models q' \<chi>)) \<and>
+    (\<forall>p q. p ~\<eta> q \<longrightarrow> \<psi> \<in> \<O>_conjunct e\<eta> \<longrightarrow> hml_srbb_conjunct_models p \<psi> \<longrightarrow> hml_srbb_conjunct_models q \<psi>)\<close>
   proof-
     fix \<phi> \<chi> \<psi>
     show
-      \<open>(\<forall>p q. p ~\<eta> q \<longrightarrow> \<phi> \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>) \<longrightarrow> p \<Turnstile>SRBB \<phi> \<longrightarrow> q \<Turnstile>SRBB \<phi>) \<and>
-      (\<forall>p q. p ~\<eta> q \<longrightarrow> \<chi> \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>) \<longrightarrow> hml_srbb_inner_models p \<chi> \<longrightarrow> (\<exists>q'. q \<Zsurj> q' \<and> hml_srbb_inner_models q' \<chi>)) \<and>
-      (\<forall>p q. p ~\<eta> q \<longrightarrow> \<psi> \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>) \<longrightarrow> hml_srbb_conjunct_models p \<psi> \<longrightarrow> hml_srbb_conjunct_models q \<psi>)\<close>
+      \<open>(\<forall>p q. p ~\<eta> q \<longrightarrow> \<phi> \<in> \<O> e\<eta> \<longrightarrow> p \<Turnstile>SRBB \<phi> \<longrightarrow> q \<Turnstile>SRBB \<phi>) \<and>
+      (\<forall>p q. p ~\<eta> q \<longrightarrow> \<chi> \<in> \<O>_inner e\<eta> \<longrightarrow> hml_srbb_inner_models p \<chi> \<longrightarrow> (\<exists>q'. q \<Zsurj> q' \<and> hml_srbb_inner_models q' \<chi>)) \<and>
+      (\<forall>p q. p ~\<eta> q \<longrightarrow> \<psi> \<in> \<O>_conjunct e\<eta> \<longrightarrow> hml_srbb_conjunct_models p \<psi> \<longrightarrow> hml_srbb_conjunct_models q \<psi>)\<close>
     proof (induct rule: hml_srbb_hml_srbb_inner_hml_srbb_conjunct.induct)
       case TT
       then show ?case by simp
@@ -84,9 +86,9 @@ proof -
       proof safe
         fix p q
         assume case_assms:
-          \<open>p ~\<eta> q\<close> \<open>p \<Turnstile>SRBB hml_srbb.Internal \<chi>\<close> \<open>Internal \<chi> \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+          \<open>p ~\<eta> q\<close> \<open>p \<Turnstile>SRBB hml_srbb.Internal \<chi>\<close> \<open>Internal \<chi> \<in> \<O> e\<eta>\<close>
         then obtain p' where p'_spec: \<open>p \<Zsurj> p'\<close> \<open>hml_srbb_inner_models p' \<chi>\<close> by auto
-        have \<open>\<chi> \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+        have \<open>\<chi> \<in> \<O>_inner e\<eta>\<close>
           using case_assms(3) unfolding \<O>_inner_def \<O>_def by auto
         hence \<open>\<exists>q'. q \<Zsurj> q' \<and> hml_srbb_inner_models q' \<chi>\<close>
           using Internal case_assms(1) p'_spec eta_bisimulated_silently_retained
@@ -103,9 +105,9 @@ proof -
         fix p q
         assume case_assms:
           \<open>p ~\<eta> q\<close>
-          \<open>Obs \<alpha> \<phi> \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+          \<open>Obs \<alpha> \<phi> \<in> \<O>_inner e\<eta>\<close>
           \<open>hml_srbb_inner_models p (hml_srbb_inner.Obs \<alpha> \<phi>)\<close>
-        hence \<open>\<phi> \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close> unfolding \<O>_inner_def \<O>_def by auto
+        hence \<open>\<phi> \<in> \<O> e\<eta>\<close> unfolding \<O>_inner_def \<O>_def by auto
         hence no_imm_conj: \<open>\<nexists>I \<Psi>. \<phi> = ImmConj I \<Psi> \<and> I \<noteq> {}\<close> unfolding \<O>_def by force
         have back_step: \<open>\<forall>p0 p1. p1 \<Turnstile>SRBB \<phi> \<longrightarrow> p0 \<Zsurj> p1 \<longrightarrow> p0 \<Turnstile>SRBB \<phi>\<close>
         proof (cases \<phi>)
@@ -123,7 +125,7 @@ proof -
         then obtain q' q'' q''' where \<open>q \<Zsurj> q'\<close> \<open>q' \<mapsto>a \<alpha> q''\<close> \<open>q'' \<Zsurj> q'''\<close>  \<open>p' ~\<eta> q'''\<close>
           using \<open>p ~\<eta> q\<close> eta_bisim_sim unfolding eta_simulation_def
           using silent_reachable.refl by blast
-        hence \<open>q''' \<Turnstile>SRBB \<phi>\<close> using \<open>p' \<Turnstile>SRBB \<phi>\<close> Obs \<open>\<phi> \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close> by blast
+        hence \<open>q''' \<Turnstile>SRBB \<phi>\<close> using \<open>p' \<Turnstile>SRBB \<phi>\<close> Obs \<open>\<phi> \<in> \<O> e\<eta>\<close> by blast
         hence \<open>hml_srbb_inner_models q' (hml_srbb_inner.Obs \<alpha> \<phi>)\<close>
           using \<open>q' \<mapsto>a \<alpha> q''\<close> \<open>q'' \<Zsurj> q'''\<close> back_step by auto
         thus \<open>\<exists>q'. q \<Zsurj> q' \<and> hml_srbb_inner_models q' (hml_srbb_inner.Obs \<alpha> \<phi>)\<close>
@@ -136,9 +138,9 @@ proof -
         fix p q
         assume case_assms:
           \<open>p ~\<eta> q\<close>
-          \<open>Conj I \<Psi> \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+          \<open>Conj I \<Psi> \<in> \<O>_inner e\<eta>\<close>
           \<open>hml_srbb_inner_models p (Conj I \<Psi>)\<close>
-        hence conj_price: \<open>\<forall>i\<in>I. \<Psi> i \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+        hence conj_price: \<open>\<forall>i\<in>I. \<Psi> i \<in> \<O>_conjunct e\<eta>\<close>
           unfolding \<O>_conjunct_def \<O>_inner_def
           by (simp, metis SUP_bot_conv(1) le_zero_eq sup_bot_left sup_ge1)
         from case_assms have \<open>\<forall>i\<in>I. hml_srbb_conjunct_models p (\<Psi> i)\<close> by auto
@@ -158,9 +160,9 @@ proof -
         fix p q
         assume case_assms:
           \<open>p ~\<eta> q\<close>
-          \<open>BranchConj \<alpha> \<phi> I \<Psi> \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+          \<open>BranchConj \<alpha> \<phi> I \<Psi> \<in> \<O>_inner e\<eta>\<close>
           \<open>hml_srbb_inner_models p (BranchConj \<alpha> \<phi> I \<Psi>)\<close>
-        hence \<open>\<phi> \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close> unfolding \<O>_inner_def \<O>_def
+        hence \<open>\<phi> \<in> \<O> e\<eta>\<close> unfolding \<O>_inner_def \<O>_def
           by (simp, metis le_zero_eq sup_ge1)
         hence no_imm_conj: \<open>\<nexists>I \<Psi>. \<phi> = ImmConj I \<Psi> \<and> I \<noteq> {}\<close> unfolding \<O>_def by force
         have back_step: \<open>\<forall>p0 p1. p1 \<Turnstile>SRBB \<phi> \<longrightarrow> p0 \<Zsurj> p1 \<longrightarrow> p0 \<Turnstile>SRBB \<phi>\<close>
@@ -175,7 +177,7 @@ proof -
           case (ImmConj _ _)
           then show ?thesis using no_imm_conj by auto
         qed
-        from case_assms have conj_price: \<open>\<forall>i\<in>I. \<Psi> i \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+        from case_assms have conj_price: \<open>\<forall>i\<in>I. \<Psi> i \<in> \<O>_conjunct e\<eta>\<close>
           unfolding \<O>_conjunct_def \<O>_inner_def
           by (simp, metis SUP_bot_conv(1) le_zero_eq sup_bot_left sup_ge1)
         from case_assms have \<open>\<forall>i\<in>I. hml_srbb_conjunct_models p (\<Psi> i)\<close>
@@ -188,7 +190,7 @@ proof -
           using eta_bisim_sim \<open>p ~\<eta> q\<close> silent_reachable.refl
           unfolding eta_simulation_def by blast
         hence \<open>q''' \<Turnstile>SRBB \<phi>\<close>
-          using BranchConj.hyps \<open>p' \<Turnstile>SRBB \<phi>\<close> \<open>\<phi> \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close> by auto
+          using BranchConj.hyps \<open>p' \<Turnstile>SRBB \<phi>\<close> \<open>\<phi> \<in> \<O> e\<eta>\<close> by auto
         hence \<open>q'' \<Turnstile>SRBB \<phi>\<close> using back_step q'_q''_spec by blast
         hence \<open>hml_srbb_inner_models q' (Obs \<alpha> \<phi>)\<close> using q'_q''_spec by auto
         moreover have \<open>\<forall>i\<in>I. hml_srbb_conjunct_models q' (\<Psi> i)\<close>
@@ -204,13 +206,13 @@ proof -
         fix p q
         assume case_assms:
           \<open>p ~\<eta> q\<close>
-          \<open>Pos \<chi> \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+          \<open>Pos \<chi> \<in> \<O>_conjunct e\<eta>\<close>
           \<open>hml_srbb_conjunct_models p (Pos \<chi>)\<close>
-        hence \<open>\<chi> \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+        hence \<open>\<chi> \<in> \<O>_inner e\<eta>\<close>
           unfolding \<O>_inner_def \<O>_conjunct_def by simp
         from case_assms obtain p' where \<open>p \<Zsurj> p'\<close> \<open>hml_srbb_inner_models p' \<chi>\<close> by auto
         then obtain q' where \<open>q \<Zsurj> q'\<close> \<open>hml_srbb_inner_models q' \<chi>\<close>
-          using Pos \<open>p ~\<eta> q\<close> \<open>\<chi> \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+          using Pos \<open>p ~\<eta> q\<close> \<open>\<chi> \<in> \<O>_inner e\<eta>\<close>
           by (meson eta_bisimulated_silently_retained silent_reachable_trans)
         thus \<open>hml_srbb_conjunct_models q (Pos \<chi>)\<close> by auto
       qed
@@ -221,15 +223,15 @@ proof -
         fix p q
         assume case_assms:
           \<open>p ~\<eta> q\<close>
-          \<open>Neg \<chi> \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+          \<open>Neg \<chi> \<in> \<O>_conjunct e\<eta>\<close>
           \<open>hml_srbb_conjunct_models p (Neg \<chi>)\<close>
-        hence \<open>\<chi> \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+        hence \<open>\<chi> \<in> \<O>_inner e\<eta>\<close>
           unfolding \<O>_inner_def \<O>_conjunct_def by simp
         from case_assms have \<open>\<forall>p'. p \<Zsurj> p' \<longrightarrow> \<not>hml_srbb_inner_models p' \<chi>\<close> by simp
         moreover have
           \<open>(\<exists>q'. q \<Zsurj> q' \<and> hml_srbb_inner_models q' \<chi>) \<longrightarrow> (\<exists>p'. p \<Zsurj> p' \<and> hml_srbb_inner_models p' \<chi>)\<close>
           using Neg eta_bisim_sym[OF \<open>p ~\<eta> q\<close>] eta_bisimulated_silently_retained
-            silent_reachable_trans \<open>\<chi> \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close> by blast
+            silent_reachable_trans \<open>\<chi> \<in> \<O>_inner e\<eta>\<close> by blast
         ultimately have \<open>\<forall>q'. q \<Zsurj> q' \<longrightarrow> \<not>hml_srbb_inner_models q' \<chi>\<close> by blast
         thus \<open>hml_srbb_conjunct_models q (Neg \<chi>)\<close> by simp
       qed
@@ -238,58 +240,58 @@ proof -
   thus ?thesis using assms by blast
 qed
 
-lemma modal_eta_sim_eq: \<open>eta_simulation (equivalent (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)))\<close>
+lemma modal_eta_sim_eq: \<open>eta_simulation (equivalent (\<O> e\<eta>))\<close>
 proof -
-  have \<open>\<nexists>p \<alpha> p' q. (equivalent (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>))) p q \<and> p \<mapsto> \<alpha> p' \<and>
-      (\<alpha> \<noteq> \<tau> \<or> \<not>(equivalent (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>))) p' q) \<and>
+  have \<open>\<nexists>p \<alpha> p' q. (equivalent (\<O> e\<eta>)) p q \<and> p \<mapsto> \<alpha> p' \<and>
+      (\<alpha> \<noteq> \<tau> \<or> \<not>(equivalent (\<O> e\<eta>)) p' q) \<and>
       (\<forall>q' q'' q'''. q \<Zsurj> q' \<longrightarrow> q' \<mapsto> \<alpha> q'' \<longrightarrow> q'' \<Zsurj> q''' \<longrightarrow>
-    \<not> equivalent (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)) p q' \<or> \<not> equivalent (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)) p' q''')\<close>
+    \<not> equivalent (\<O> e\<eta>) p q' \<or> \<not> equivalent (\<O> e\<eta>) p' q''')\<close>
   proof clarify
     fix p \<alpha> p' q
-    define Q\<alpha> where \<open>Q\<alpha> \<equiv> {q'. q \<Zsurj> q' \<and> (\<nexists>\<phi>. \<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>) \<and> (distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p))}\<close>
+    define Q\<alpha> where \<open>Q\<alpha> \<equiv> {q'. q \<Zsurj> q' \<and> (\<nexists>\<phi>. \<phi>\<in>\<O> e\<eta> \<and> (distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p))}\<close>
     assume contradiction:
-      \<open>equivalent (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)) p q\<close> \<open>p \<mapsto> \<alpha> p'\<close>
+      \<open>equivalent (\<O> e\<eta>) p q\<close> \<open>p \<mapsto> \<alpha> p'\<close>
       \<open>\<forall>q' q'' q'''. q \<Zsurj> q' \<longrightarrow> q' \<mapsto> \<alpha> q'' \<longrightarrow> q'' \<Zsurj> q''' \<longrightarrow>
-      \<not> equivalent (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)) p q' \<or> \<not> equivalent (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)) p' q'''\<close>
-      \<open>\<alpha> \<noteq> \<tau> \<or> \<not> equivalent (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)) p' q\<close>
+      \<not> equivalent (\<O> e\<eta>) p q' \<or> \<not> equivalent (\<O> e\<eta>) p' q'''\<close>
+      \<open>\<alpha> \<noteq> \<tau> \<or> \<not> equivalent (\<O> e\<eta>) p' q\<close>
     hence distinctions: \<open>\<forall>q'. q \<Zsurj> q' \<longrightarrow>
-      (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>). distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p) \<or>
-      (\<forall>q'' q'''. q' \<mapsto>a \<alpha> q'' \<longrightarrow> q'' \<Zsurj> q''' \<longrightarrow> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>). distinguishes \<phi> p' q''' \<or> distinguishes \<phi> q''' p'))\<close>
+      (\<exists>\<phi>\<in>\<O> e\<eta>. distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p) \<or>
+      (\<forall>q'' q'''. q' \<mapsto>a \<alpha> q'' \<longrightarrow> q'' \<Zsurj> q''' \<longrightarrow> (\<exists>\<phi>\<in>\<O> e\<eta>. distinguishes \<phi> p' q''' \<or> distinguishes \<phi> q''' p'))\<close>
       unfolding equivalent_no_distinction
       by (metis silent_reachable.cases silent_reachable.refl)
     hence \<open>\<forall>q'' q''' . \<forall>q'\<in>Q\<alpha>.
-        q' \<mapsto>a \<alpha> q'' \<longrightarrow> q'' \<Zsurj> q''' \<longrightarrow> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>). distinguishes \<phi> p' q''' \<or> distinguishes \<phi> q''' p')\<close>
+        q' \<mapsto>a \<alpha> q'' \<longrightarrow> q'' \<Zsurj> q''' \<longrightarrow> (\<exists>\<phi>\<in>\<O> e\<eta>. distinguishes \<phi> p' q''' \<or> distinguishes \<phi> q''' p')\<close>
       unfolding Q\<alpha>_def using silent_reachable.refl by fastforce
-    hence \<open>\<forall>q'' q'''. q'' \<Zsurj> q''' \<longrightarrow> (\<exists>q'. q \<Zsurj> q' \<and> (\<nexists>\<phi>. \<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>) \<and> (distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)) \<and> q' \<mapsto>a \<alpha> q'')
-        \<longrightarrow> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>). distinguishes \<phi> p' q''' \<or> distinguishes \<phi> q''' p')\<close>
+    hence \<open>\<forall>q'' q'''. q'' \<Zsurj> q''' \<longrightarrow> (\<exists>q'. q \<Zsurj> q' \<and> (\<nexists>\<phi>. \<phi>\<in>\<O> e\<eta> \<and> (distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)) \<and> q' \<mapsto>a \<alpha> q'')
+        \<longrightarrow> (\<exists>\<phi>\<in>\<O> e\<eta>. distinguishes \<phi> p' q''' \<or> distinguishes \<phi> q''' p')\<close>
       unfolding Q\<alpha>_def by blast
-    hence \<open>\<forall>q'''. (\<exists>q' q''. q \<Zsurj> q' \<and> (\<nexists>\<phi>. \<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>) \<and> (distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)) \<and> q' \<mapsto>a \<alpha> q'' \<and>  q'' \<Zsurj> q''')
-        \<longrightarrow> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>). distinguishes \<phi> p' q''' \<or> distinguishes \<phi> q''' p')\<close>
+    hence \<open>\<forall>q'''. (\<exists>q' q''. q \<Zsurj> q' \<and> (\<nexists>\<phi>. \<phi>\<in>\<O> e\<eta> \<and> (distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)) \<and> q' \<mapsto>a \<alpha> q'' \<and>  q'' \<Zsurj> q''')
+        \<longrightarrow> (\<exists>\<phi>\<in>\<O> e\<eta>. distinguishes \<phi> p' q''' \<or> distinguishes \<phi> q''' p')\<close>
       by blast
     then obtain \<Phi>\<alpha> where \<Phi>\<alpha>_def:
-      \<open>\<forall>q'''. (\<exists>q' q''. q \<Zsurj> q' \<and> (\<nexists>\<phi>. \<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>) \<and> (distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)) \<and> q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q''')
-        \<longrightarrow> (\<Phi>\<alpha> q''') \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>) \<and> (distinguishes (\<Phi>\<alpha> q''') p' q''' \<or> distinguishes (\<Phi>\<alpha> q''') q''' p')\<close> by metis
+      \<open>\<forall>q'''. (\<exists>q' q''. q \<Zsurj> q' \<and> (\<nexists>\<phi>. \<phi>\<in>\<O> e\<eta> \<and> (distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)) \<and> q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q''')
+        \<longrightarrow> (\<Phi>\<alpha> q''') \<in> \<O> e\<eta> \<and> (distinguishes (\<Phi>\<alpha> q''') p' q''' \<or> distinguishes (\<Phi>\<alpha> q''') q''' p')\<close> by metis
     hence distinctions_\<alpha>: \<open>\<forall>q'\<in>Q\<alpha>. \<forall>q'' q'''.
         q' \<mapsto>a \<alpha> q'' \<longrightarrow> q'' \<Zsurj> q''' \<longrightarrow> distinguishes (\<Phi>\<alpha> q''') p' q''' \<or> distinguishes (\<Phi>\<alpha> q''') q''' p'\<close>
       unfolding Q\<alpha>_def by blast
     from distinctions obtain \<Phi>\<eta> where
-      \<open>\<forall>q'. q'\<in>{q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>). distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)}
-        \<longrightarrow> (distinguishes (\<Phi>\<eta> q') p q' \<or> distinguishes (\<Phi>\<eta> q') q' p) \<and> (\<Phi>\<eta> q') \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+      \<open>\<forall>q'. q'\<in>{q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> e\<eta>. distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)}
+        \<longrightarrow> (distinguishes (\<Phi>\<eta> q') p q' \<or> distinguishes (\<Phi>\<eta> q') q' p) \<and> (\<Phi>\<eta> q') \<in> \<O> e\<eta>\<close>
       unfolding mem_Collect_eq by moura
     hence
-      \<open>\<forall>q'\<in>{q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>). distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)}.
+      \<open>\<forall>q'\<in>{q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> e\<eta>. distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)}.
         (distinguishes (\<Phi>\<eta> q') p q' \<or> distinguishes (\<Phi>\<eta> q') q' p)\<close>
-      \<open>\<forall>q'\<in>{q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>). distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)}.
-         (\<Phi>\<eta> q') \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+      \<open>\<forall>q'\<in>{q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> e\<eta>. distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)}.
+         (\<Phi>\<eta> q') \<in> \<O> e\<eta>\<close>
       by blast+
     from distinction_conjunctification_two_way[OF this(1)] distinction_conjunctification_two_way_price[OF this]
-      have \<open>\<forall>q'\<in>{q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>). distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)}.
+      have \<open>\<forall>q'\<in>{q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> e\<eta>. distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)}.
         hml_srbb_conj.distinguishes ((if distinguishes (\<Phi>\<eta> q') p q' then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi>\<eta> p q') p q' \<and>
-         (if distinguishes (\<Phi>\<eta> q') p q' then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi>\<eta> p q' \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+         (if distinguishes (\<Phi>\<eta> q') p q' then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi>\<eta> p q' \<in> \<O>_conjunct e\<eta>\<close>
         by blast
     then obtain \<Psi>\<eta> where distinctions_\<eta>:
-      \<open>\<forall>q'\<in>{q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>). distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)}.
-        hml_srbb_conj.distinguishes (\<Psi>\<eta> q') p q' \<and> \<Psi>\<eta> q' \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+      \<open>\<forall>q'\<in>{q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> e\<eta>. distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)}.
+        hml_srbb_conj.distinguishes (\<Psi>\<eta> q') p q' \<and> \<Psi>\<eta> q' \<in> \<O>_conjunct e\<eta>\<close>
       by auto
     have \<open>p \<mapsto>a \<alpha> p'\<close> using \<open>p \<mapsto> \<alpha> p'\<close> by auto
     from distinction_combination_eta_two_way[OF this, of q \<Phi>\<alpha>] distinctions_\<alpha> have obs_dist:
@@ -301,12 +303,12 @@ proof -
     have \<open>Q\<alpha> \<noteq> {}\<close>
       using Q\<alpha>_def contradiction(1) silent_reachable.refl by fastforce
     hence conjunct_prices: \<open>\<forall>q'''\<in>{q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}.
-          ((if distinguishes (\<Phi>\<alpha> q''') p' q''' then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi>\<alpha> p' q''') \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+          ((if distinguishes (\<Phi>\<alpha> q''') p' q''' then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi>\<alpha> p' q''') \<in> \<O>_conjunct e\<eta>\<close>
       using distinction_conjunctification_two_way_price[of \<open>{q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}\<close>]
       using Q\<alpha>_def \<Phi>\<alpha>_def by auto
     have \<open>(Conj {q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}
           (\<lambda>q'''. (if distinguishes (\<Phi>\<alpha> q''') p' q''' then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi>\<alpha> p'
-                   q''')) \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+                   q''')) \<in> \<O>_inner e\<eta>\<close>
     proof (cases \<open>{q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''} = {}\<close>)
       case True
       then show ?thesis
@@ -320,14 +322,14 @@ proof -
     qed
     hence obs_price: \<open>(Obs \<alpha> (Internal (Conj {q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}
          (\<lambda>q'''. (if distinguishes (\<Phi>\<alpha> q''') p' q''' then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi>\<alpha> p'
-                   q''')))) \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+                   q''')))) \<in> \<O>_inner e\<eta>\<close>
       using distinction_conjunctification_price distinctions_\<alpha> unfolding \<O>_inner_def \<O>_def by simp
     from obs_dist distinctions_\<eta> have
       \<open>hml_srbb_inner_models p (BranchConj \<alpha>
           (Internal (Conj {q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}
                    (\<lambda>q'''. (if distinguishes (\<Phi>\<alpha> q''') p' q''' then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi>\<alpha> p'
                    q''')))
-          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>). distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)} \<Psi>\<eta>)\<close>
+          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> e\<eta>. distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)} \<Psi>\<eta>)\<close>
       using \<open>Q\<alpha> \<noteq> {}\<close> silent_reachable.refl
       unfolding hml_srbb_conj.distinguishes_def hml_srbb_inner.distinguishes_def
       by (smt (verit) Q\<alpha>_def empty_Collect_eq hml_srbb_inner_models.simps(1,4) mem_Collect_eq)
@@ -336,7 +338,7 @@ proof -
           (Internal (Conj {q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}
                    (\<lambda>q'''. (if distinguishes (\<Phi>\<alpha> q''') p' q''' then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi>\<alpha> p'
                    q''')))
-          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>). distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)} \<Psi>\<eta>)\<close>
+          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> e\<eta>. distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)} \<Psi>\<eta>)\<close>
     proof safe
       fix q'
       assume contradiction: \<open>q \<Zsurj> q'\<close>
@@ -344,7 +346,7 @@ proof -
           (Internal (Conj {q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}
                    (\<lambda>q'''. (if distinguishes (\<Phi>\<alpha> q''') p' q''' then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi>\<alpha> p'
                    q''')))
-          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>). distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)} \<Psi>\<eta>)\<close>
+          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> e\<eta>. distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)} \<Psi>\<eta>)\<close>
       thus \<open>False\<close>
         using obs_dist distinctions_\<eta>  branching_conj_obs branching_conj_parts
         unfolding distinguishes_def hml_srbb_conj.distinguishes_def hml_srbb_inner.distinguishes_def Q\<alpha>_def
@@ -354,8 +356,8 @@ proof -
           (Internal (Conj {q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}
                    (\<lambda>q'''. (if distinguishes (\<Phi>\<alpha> q''') p' q''' then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi>\<alpha> p'
                    q''')))
-          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>). distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)} \<Psi>\<eta>)
-      \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> e\<eta>. distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)} \<Psi>\<eta>)
+      \<in> \<O>_inner e\<eta>\<close>
       using distinctions_\<eta> obs_price
       unfolding Q\<alpha>_def \<O>_inner_def \<O>_def \<O>_conjunct_def \<Phi>\<alpha>_def
       by (simp, metis (mono_tags, lifting) SUP_bot_conv(2) bot_enat_def sup_bot_left)
@@ -363,15 +365,15 @@ proof -
           (Internal (Conj {q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}
                    (\<lambda>q'''. (if distinguishes (\<Phi>\<alpha> q''') p' q''' then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi>\<alpha> p'
                    q''')))
-          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>). distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)} \<Psi>\<eta>)) p q\<close>
+          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> e\<eta>. distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)} \<Psi>\<eta>)) p q\<close>
       unfolding distinguishes_def Q\<alpha>_def
       using silent_reachable.refl hml_srbb_models.simps(2) by blast
     moreover have \<open>(Internal (BranchConj \<alpha>
           (Internal (Conj {q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}
                    (\<lambda>q'''. (if distinguishes (\<Phi>\<alpha> q''') p' q''' then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi>\<alpha> p'
                    q''')))
-          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>). distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)} \<Psi>\<eta>))
-      \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> e\<eta>. distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p)} \<Psi>\<eta>))
+      \<in> \<O> e\<eta>\<close>
       using branch_price
       unfolding Q\<alpha>_def \<O>_def \<O>_conjunct_def
       by (metis (no_types, lifting) \<O>_inner_def expr_internal_eq mem_Collect_eq)
@@ -381,53 +383,53 @@ proof -
     unfolding eta_simulation_def by blast
 qed
 
-theorem \<open>(p ~\<eta> q) = (p \<sim> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>) q)\<close>
+theorem \<open>(p ~\<eta> q) = (p \<sim> e\<eta> q)\<close>
   using modal_eta_sim_eq logic_eta_bisim_invariant sympD equivalent_no_distinction
   unfolding eta_bisimulated_def expr_equiv_def distinguishes_def
   by (smt (verit, best) equivalent_equiv equivpE)
 
 \<comment>\<open>This proof essentially is a simpler version of the proof for the equivalence\<close>
-lemma modal_eta_sim: \<open>eta_simulation (preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0)))\<close>
+lemma modal_eta_sim: \<open>eta_simulation (preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0)))\<close>
 proof -
-  have \<open>\<nexists>p \<alpha> p' q. (preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0))) p q \<and> p \<mapsto> \<alpha> p' \<and>
-      (\<alpha> \<noteq> \<tau> \<or> \<not>(preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0))) p' q) \<and>
+  have \<open>\<nexists>p \<alpha> p' q. (preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0))) p q \<and> p \<mapsto> \<alpha> p' \<and>
+      (\<alpha> \<noteq> \<tau> \<or> \<not>(preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0))) p' q) \<and>
       (\<forall>q' q'' q'''. q \<Zsurj> q' \<longrightarrow> q' \<mapsto> \<alpha> q'' \<longrightarrow> q'' \<Zsurj> q''' \<longrightarrow>
-    \<not> preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0)) p q' \<or> \<not> preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0)) p' q''')\<close>
+    \<not> preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0)) p q' \<or> \<not> preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0)) p' q''')\<close>
   proof clarify
-    have less_obs: \<open>modal_depth (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0) \<le> pos_conjuncts (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0)\<close> by simp
+    have less_obs: \<open>modal_depth (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0) \<le> pos_conjuncts (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0)\<close> by simp
     fix p \<alpha> p' q
-    define Q\<alpha> where \<open>Q\<alpha> \<equiv> {q'. q \<Zsurj> q' \<and> (\<nexists>\<phi>. \<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0) \<and> distinguishes \<phi> p q')}\<close>
+    define Q\<alpha> where \<open>Q\<alpha> \<equiv> {q'. q \<Zsurj> q' \<and> (\<nexists>\<phi>. \<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0) \<and> distinguishes \<phi> p q')}\<close>
     assume contradiction:
-      \<open>preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0)) p q\<close> \<open>p \<mapsto> \<alpha> p'\<close>
+      \<open>preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0)) p q\<close> \<open>p \<mapsto> \<alpha> p'\<close>
       \<open>\<forall>q' q'' q'''. q \<Zsurj> q' \<longrightarrow> q' \<mapsto> \<alpha> q'' \<longrightarrow> q'' \<Zsurj> q''' \<longrightarrow>
-      \<not> preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0)) p q' \<or> \<not> preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0)) p' q'''\<close>
-      \<open>\<alpha> \<noteq> \<tau> \<or> \<not> preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0)) p' q\<close>
+      \<not> preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0)) p q' \<or> \<not> preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0)) p' q'''\<close>
+      \<open>\<alpha> \<noteq> \<tau> \<or> \<not> preordered (\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0)) p' q\<close>
     hence distinctions: \<open>\<forall>q'. q \<Zsurj> q' \<longrightarrow>
-      (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0). distinguishes \<phi> p q') \<or>
-      (\<forall>q'' q'''. q' \<mapsto>a \<alpha> q'' \<longrightarrow> q'' \<Zsurj> q''' \<longrightarrow> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0). distinguishes \<phi> p' q'''))\<close>
+      (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0). distinguishes \<phi> p q') \<or>
+      (\<forall>q'' q'''. q' \<mapsto>a \<alpha> q'' \<longrightarrow> q'' \<Zsurj> q''' \<longrightarrow> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0). distinguishes \<phi> p' q'''))\<close>
       unfolding preordered_no_distinction
       by (metis silent_reachable.cases silent_reachable.refl)
     hence \<open>\<forall>q'' q''' . \<forall>q'\<in>Q\<alpha>.
-        q' \<mapsto>a \<alpha> q'' \<longrightarrow> q'' \<Zsurj> q''' \<longrightarrow> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0). distinguishes \<phi> p' q''')\<close>
+        q' \<mapsto>a \<alpha> q'' \<longrightarrow> q'' \<Zsurj> q''' \<longrightarrow> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0). distinguishes \<phi> p' q''')\<close>
       unfolding Q\<alpha>_def using silent_reachable.refl by fastforce
-    hence \<open>\<forall>q'' q'''. q'' \<Zsurj> q''' \<longrightarrow> (\<exists>q'. q \<Zsurj> q' \<and> (\<nexists>\<phi>. \<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0) \<and> distinguishes \<phi> p q') \<and> q' \<mapsto>a \<alpha> q'')
-        \<longrightarrow> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0). distinguishes \<phi> p' q''')\<close>
+    hence \<open>\<forall>q'' q'''. q'' \<Zsurj> q''' \<longrightarrow> (\<exists>q'. q \<Zsurj> q' \<and> (\<nexists>\<phi>. \<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0) \<and> distinguishes \<phi> p q') \<and> q' \<mapsto>a \<alpha> q'')
+        \<longrightarrow> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0). distinguishes \<phi> p' q''')\<close>
       unfolding Q\<alpha>_def by blast
-    hence \<open>\<forall>q'''. (\<exists>q' q''. q \<Zsurj> q' \<and> (\<nexists>\<phi>. \<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0) \<and> distinguishes \<phi> p q') \<and> q' \<mapsto>a \<alpha> q'' \<and>  q'' \<Zsurj> q''')
-        \<longrightarrow> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0). distinguishes \<phi> p' q''')\<close>
+    hence \<open>\<forall>q'''. (\<exists>q' q''. q \<Zsurj> q' \<and> (\<nexists>\<phi>. \<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0) \<and> distinguishes \<phi> p q') \<and> q' \<mapsto>a \<alpha> q'' \<and>  q'' \<Zsurj> q''')
+        \<longrightarrow> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0). distinguishes \<phi> p' q''')\<close>
       by blast
     then obtain \<Phi>\<alpha> where \<Phi>\<alpha>_def:
-      \<open>\<forall>q'''. (\<exists>q' q''. q \<Zsurj> q' \<and> (\<nexists>\<phi>. \<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0) \<and> distinguishes \<phi> p q') \<and> q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q''')
-        \<longrightarrow> (\<Phi>\<alpha> q''') \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0) \<and> distinguishes (\<Phi>\<alpha> q''') p' q'''\<close> by metis
+      \<open>\<forall>q'''. (\<exists>q' q''. q \<Zsurj> q' \<and> (\<nexists>\<phi>. \<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0) \<and> distinguishes \<phi> p q') \<and> q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q''')
+        \<longrightarrow> (\<Phi>\<alpha> q''') \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0) \<and> distinguishes (\<Phi>\<alpha> q''') p' q'''\<close> by metis
     hence distinctions_\<alpha>: \<open>\<forall>q'\<in>Q\<alpha>. \<forall>q'' q'''.
         q' \<mapsto>a \<alpha> q'' \<longrightarrow> q'' \<Zsurj> q''' \<longrightarrow> distinguishes (\<Phi>\<alpha> q''') p' q'''\<close>
       unfolding Q\<alpha>_def by blast
     from distinctions obtain \<Phi>\<eta> where
-      \<open>\<forall>q'. q'\<in>{q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0). distinguishes \<phi> p q')}
-        \<longrightarrow> distinguishes (\<Phi>\<eta> q') p q' \<and> (\<Phi>\<eta> q') \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0)\<close> unfolding mem_Collect_eq by moura
+      \<open>\<forall>q'. q'\<in>{q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0). distinguishes \<phi> p q')}
+        \<longrightarrow> distinguishes (\<Phi>\<eta> q') p q' \<and> (\<Phi>\<eta> q') \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0)\<close> unfolding mem_Collect_eq by moura
     then obtain \<Psi>\<eta> where distinctions_\<eta>:
-      \<open>\<forall>q'\<in>{q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0). distinguishes \<phi> p q')}.
-        hml_srbb_conj.distinguishes (\<Psi>\<eta> q') p q' \<and> (\<Psi>\<eta> q') \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0)\<close>
+      \<open>\<forall>q'\<in>{q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0). distinguishes \<phi> p q')}.
+        hml_srbb_conj.distinguishes (\<Psi>\<eta> q') p q' \<and> (\<Psi>\<eta> q') \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0)\<close>
       using less_obs  distinction_conjunctification distinction_conjunctification_price
       by (smt (verit, del_insts))
     have \<open>p \<mapsto>a \<alpha> p'\<close> using \<open>p \<mapsto> \<alpha> p'\<close> by auto
@@ -439,11 +441,11 @@ proof -
     have \<open>Q\<alpha> \<noteq> {}\<close>
       using Q\<alpha>_def contradiction(1) silent_reachable.refl by fastforce
     hence conjunct_prices: \<open>\<forall>q'''\<in>{q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}.
-          (conjunctify_distinctions \<Phi>\<alpha> p' q''') \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0)\<close>
+          (conjunctify_distinctions \<Phi>\<alpha> p' q''') \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0)\<close>
       using distinction_conjunctification_price[of \<open>{q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}\<close>]
       using Q\<alpha>_def \<Phi>\<alpha>_def by auto
     have \<open>(Conj {q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}
-          (conjunctify_distinctions \<Phi>\<alpha> p')) \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0)\<close>
+          (conjunctify_distinctions \<Phi>\<alpha> p')) \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0)\<close>
     proof (cases \<open>{q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''} = {}\<close>)
       case True
       then show ?thesis
@@ -456,27 +458,27 @@ proof -
         unfolding \<O>_inner_def \<O>_conjunct_def by force
     qed
     hence obs_price: \<open>(Obs \<alpha> (Internal (Conj {q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}
-         (conjunctify_distinctions \<Phi>\<alpha> p')))) \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0)\<close>
+         (conjunctify_distinctions \<Phi>\<alpha> p')))) \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0)\<close>
       using distinction_conjunctification_price distinctions_\<alpha> unfolding \<O>_inner_def \<O>_def by simp
     from obs_dist distinctions_\<eta> have
       \<open>hml_srbb_inner_models p (BranchConj \<alpha>
           (Internal (Conj {q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}
                    (conjunctify_distinctions \<Phi>\<alpha> p')))
-          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0). distinguishes \<phi> p q')} \<Psi>\<eta>)\<close>
+          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0). distinguishes \<phi> p q')} \<Psi>\<eta>)\<close>
       using contradiction(1) silent_reachable.refl
       unfolding Q\<alpha>_def by force
     moreover have \<open>\<forall>q'. q \<Zsurj> q' \<longrightarrow> \<not> hml_srbb_inner_models q'
         (BranchConj \<alpha>
           (Internal (Conj {q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}
                    (conjunctify_distinctions \<Phi>\<alpha> p')))
-          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0). distinguishes \<phi> p q')} \<Psi>\<eta>)\<close>
+          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0). distinguishes \<phi> p q')} \<Psi>\<eta>)\<close>
     proof safe
       fix q'
       assume contradiction: \<open>q \<Zsurj> q'\<close>
         \<open>hml_srbb_inner_models q' (BranchConj \<alpha>
           (Internal (Conj {q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}
                    (conjunctify_distinctions \<Phi>\<alpha> p')))
-          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0). distinguishes \<phi> p q')} \<Psi>\<eta>)\<close>
+          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0). distinguishes \<phi> p q')} \<Psi>\<eta>)\<close>
       thus \<open>False\<close>
         using obs_dist distinctions_\<eta>
         unfolding distinguishes_def hml_srbb_conj.distinguishes_def hml_srbb_inner.distinguishes_def Q\<alpha>_def
@@ -485,22 +487,22 @@ proof -
     moreover have branch_price: \<open>(BranchConj \<alpha>
           (Internal (Conj {q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}
                    (conjunctify_distinctions \<Phi>\<alpha> p')))
-          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0). distinguishes \<phi> p q')} \<Psi>\<eta>)
-      \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0)\<close>
+          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0). distinguishes \<phi> p q')} \<Psi>\<eta>)
+      \<in> \<O>_inner (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0)\<close>
       using distinctions_\<eta> obs_price
       unfolding Q\<alpha>_def \<O>_inner_def \<O>_def \<O>_conjunct_def \<Phi>\<alpha>_def
       by (simp, metis (mono_tags, lifting) SUP_bot_conv(2) bot_enat_def sup_bot_left)
     ultimately have \<open>distinguishes (Internal (BranchConj \<alpha>
           (Internal (Conj {q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}
                    (conjunctify_distinctions \<Phi>\<alpha> p')))
-          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0). distinguishes \<phi> p q')} \<Psi>\<eta>)) p q\<close>
+          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0). distinguishes \<phi> p q')} \<Psi>\<eta>)) p q\<close>
       unfolding distinguishes_def Q\<alpha>_def
       using silent_reachable.refl hml_srbb_models.simps(2) by blast
     moreover have \<open>(Internal (BranchConj \<alpha>
           (Internal (Conj {q'''. \<exists>q'\<in>Q\<alpha>. \<exists>q''. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Zsurj> q'''}
                    (conjunctify_distinctions \<Phi>\<alpha> p')))
-          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0). distinguishes \<phi> p q')} \<Psi>\<eta>))
-      \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0)\<close>
+          {q'. q \<Zsurj> q' \<and> (\<exists>\<phi>\<in>\<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0). distinguishes \<phi> p q')} \<Psi>\<eta>))
+      \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0)\<close>
       using branch_price
       unfolding Q\<alpha>_def \<O>_def \<O>_conjunct_def
       by (metis (no_types, lifting) \<O>_inner_def expr_internal_eq mem_Collect_eq)
@@ -510,7 +512,7 @@ proof -
     unfolding eta_simulation_def by blast
 qed
 
-theorem \<open>(p \<preceq> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0) q) \<Longrightarrow> (\<exists>R. eta_simulation R \<and> R p q)\<close>
+theorem \<open>(p \<preceq> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0) q) \<Longrightarrow> (\<exists>R. eta_simulation R \<and> R p q)\<close>
   using modal_eta_sim unfolding expr_preord_def
   by auto
 

--- a/Expressiveness_Price.thy
+++ b/Expressiveness_Price.thy
@@ -414,7 +414,7 @@ primrec
 
   \<open>neg_depth_inner (Obs _ \<phi>) = negation_depth \<phi>\<close> |
   \<open>neg_depth_inner (Conj I \<psi>s) = Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I)\<close> |
-  \<open>neg_depth_inner (StableConj I \<psi>s) = Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I)\<close> |
+  \<open>neg_depth_inner (StableConj I \<psi>s) = Sup ({1} \<union>  (neg_depth_conjunct \<circ> \<psi>s) ` I)\<close> |
   \<open>neg_depth_inner (BranchConj _ \<phi> I \<psi>s) = Sup ({negation_depth \<phi>} \<union> ((neg_depth_conjunct \<circ> \<psi>s) ` I))\<close> |
 
   \<open>neg_depth_conjunct (Pos \<chi>) = neg_depth_inner \<chi>\<close> |
@@ -660,6 +660,7 @@ lemma expr_st_conj:
     \<open>I \<noteq> {}\<close>
     \<open>\<forall>q \<in> I. expr_pr_conjunct (\<psi>s q) \<le> e'\<close>
     \<open>\<forall>q \<in> I - revival_conjunct_index I \<psi>s. is_pos (\<psi>s q) \<longrightarrow> modal_depth_srbb_conjunct (\<psi>s q) \<le> pos_conjuncts_sec e'\<close>
+    \<open>0 < neg_depth e\<close>
   shows
     \<open>expr_pr_inner (StableConj I \<psi>s) \<le> e\<close>
 proof -
@@ -674,7 +675,7 @@ proof -
       Sup (((\<lambda>\<psi>. case \<psi> of (Pos \<chi>) \<Rightarrow> modal_depth_srbb_inner \<chi> | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct \<psi>) \<circ> \<psi>s)   
         ` (I - (revival_conjunct_index I \<psi>s)))\<close>
     \<open>max_neg_conj_depth_inner (StableConj I \<psi>s) = Sup ((max_neg_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
-    \<open>neg_depth_inner (StableConj I \<psi>s) = Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I)\<close>
+    \<open>neg_depth_inner (StableConj I \<psi>s) = Sup ({1} \<union> (neg_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     by force+
   obtain e1 e2 e3 e4 e5 e6 e7 e8 e9 where e_def: \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8 e9\<close>
     using energy.exhaust_sel by blast
@@ -692,7 +693,8 @@ proof -
     \<open>\<forall>q \<in> I - revival_conjunct_index I \<psi>s. is_pos (\<psi>s q) \<longrightarrow> modal_depth_srbb_conjunct (\<psi>s q) \<le> e7\<close>
     \<open>\<forall>i \<in> I. max_neg_conj_depth_conjunct (\<psi>s i) \<le> e8\<close>
     \<open>\<forall>i \<in> I. neg_depth_conjunct (\<psi>s i) \<le> e9\<close>
-    using assms unfolding leq_components
+    \<open>0 < e9\<close>
+    using assms unfolding leq_components e_def
     by auto
   hence sups:
     \<open>Sup ((modal_depth_srbb_conjunct \<circ> \<psi>s) ` I) \<le> e1\<close>
@@ -713,9 +715,9 @@ proof -
     using e_leqs(8,10) modal_depth_srbb_rewrite
     by (metis Diff_iff e_leqs(7) hml_srbb_conjunct.case_eq_if hml_srbb_conjunct.collapse(1))
   ultimately show ?thesis
-    using st_conj_upds sups \<open>subtract_fn  0 0 0 1 0 0 0 0 0 e = Some e'\<close>
+    using st_conj_upds sups \<open>subtract_fn  0 0 0 1 0 0 0 0 0 e = Some e'\<close> \<open>0 < e9\<close>
     unfolding e_def
-    by (auto simp add:  SUP_le_iff)    
+    by (auto simp add: SUP_le_iff ileI1 one_eSuc)
 qed
 
 lemma expr_imm_conj:
@@ -1259,7 +1261,10 @@ proof
 qed
 
 lemma modal_stability_respecting:
-  \<open>stability_respecting (preordered (\<O> (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)))\<close>
+  assumes
+    \<open>0 < e9\<close>
+  shows
+    \<open>stability_respecting (preordered (\<O> (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)))\<close>
   unfolding stability_respecting_def
 proof safe
   fix p q
@@ -1282,7 +1287,8 @@ proof safe
       by fastforce
     hence conj_price: \<open>StableConj (silent_reachable_set {q} \<inter> {q'. stable_state q'}) (conjunctify_distinctions \<Phi> p)
         \<in> \<O>_inner (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)\<close>
-      unfolding \<O>_inner_def \<O>_conjunct_def using SUP_le_iff by fastforce
+      unfolding \<O>_inner_def \<O>_conjunct_def using SUP_le_iff ileI1[OF \<open>0 < e9\<close>] one_eSuc
+      by (fastforce simp add: SUP_le_iff)
     from \<Phi>_def have
       \<open>\<forall>q'\<in>(silent_reachable_set {q}). stable_state q' \<longrightarrow>
          hml_srbb_conj.distinguishes (conjunctify_distinctions \<Phi> p q') p q'\<close>

--- a/Expressiveness_Price.thy
+++ b/Expressiveness_Price.thy
@@ -854,6 +854,13 @@ proof-
     by (simp add: e_def)
 qed
 
+lemma conj_price_transfer:
+  assumes
+    \<open>expr_pr_inner (Conj I \<Psi>) \<le> e\<close>
+  shows
+    \<open>expressiveness_price (ImmConj I \<Psi>) - E 0 0 0 0 1 0 0 0 0 \<le> e\<close>
+  using assms by auto
+
 lemma expr_br_conj:
   assumes
     \<open>subtract_fn 0 1 1 0 0 0 0 0 0 e = Some e'\<close>

--- a/Expressiveness_Price.thy
+++ b/Expressiveness_Price.thy
@@ -278,14 +278,13 @@ lemma modal_depth_dominates_pos_conjuncts:
   by (auto simp add: SUP_mono' add_increasing sup.coboundedI1 sup.coboundedI2)
 
 \<comment>\<open>Supremum after some maximal element has been removed\<close>
-definition revival_conjunct_index :: \<open>'s set \<Rightarrow> ('s \<Rightarrow> ('a, 's) hml_srbb_conjunct) \<Rightarrow> 's set\<close> where
+definition revival_conjunct_index :: \<open>'s option set \<Rightarrow> ('s option \<Rightarrow> ('a, 's) hml_srbb_conjunct) \<Rightarrow> 's option set\<close> where
   \<open>revival_conjunct_index I \<psi>s \<equiv>
     if (\<exists>i\<in>I. is_pos (\<psi>s i) \<and> (\<forall>j\<in>I. is_pos (\<psi>s j) \<longrightarrow>
         modal_depth_srbb_conjunct (\<psi>s j) \<le> modal_depth_srbb_conjunct (\<psi>s i))) then
       {SOME i. i\<in>I \<and> is_pos (\<psi>s i) \<and> (\<forall>j\<in>I. is_pos (\<psi>s j) \<longrightarrow>
         modal_depth_srbb_conjunct (\<psi>s j) \<le> modal_depth_srbb_conjunct (\<psi>s i))}
     else {}\<close>
-
 
 (*lemma
   assumes \<open>\<exists>j\<in>I. is_pos (\<psi>s j)\<close>
@@ -345,14 +344,14 @@ lemma max_positive_conjunct_depth_dominates_secondary:
   apply (simp add: SUP_mono' hml_srbb_conjunct.case_eq_if) defer
   using modal_depth_dominates_pos_conjuncts order_trans  apply blast
 proof -
-  fix x1 :: "'s set" and x2 :: "'s \<Rightarrow> ('a, 's) hml_srbb_conjunct"
+  fix x1 :: "'s option set" and x2 :: "'s option \<Rightarrow> ('a, 's) hml_srbb_conjunct"
   assume a1: "\<And>x2a. x2a \<in> range x2 \<Longrightarrow> max_pos_conj_secondary_depth_conjunct x2a \<le> max_pos_conj_depth_conjunct x2a"
-  obtain ss :: "('s \<Rightarrow> enat) \<Rightarrow> ('s \<Rightarrow> enat) \<Rightarrow> 's" where
-    "\<And>f fa S. \<not> f (ss f fa) \<le> fa (ss f fa) \<or> Sup (f ` S) \<le> Sup (fa ` S)"
+  obtain zz :: "('s option \<Rightarrow> enat) \<Rightarrow> ('s option \<Rightarrow> enat) \<Rightarrow> 's option" where
+    "\<And>f fa Z. \<not> f (zz f fa) \<le> fa (zz f fa) \<or> Sup (f ` Z) \<le> Sup (fa ` Z)"
     by (meson SUP_mono')
-  then have "(SUP s\<in>x1. if is_pos (x2 s) then modal_depth_srbb_inner (un_Pos (x2 s)) else max_pos_conj_secondary_depth_conjunct (x2 s)) \<le> (SUP s\<in>x1. max_pos_conj_depth_conjunct (x2 s))"
-    using a1 by (smt (z3) hml_srbb_conjunct.collapse(1) max_pos_conj_depth_conjunct.simps(1) modal_depth_dominates_pos_conjuncts modal_depth_srbb_rewrite rangeI)
-  then show "Sup ((\<lambda>s. modal_depth_srbb_inner (un_Pos (x2 s))) ` (x1 \<inter> {s. is_pos (x2 s)}) \<union> (\<lambda>s. max_pos_conj_secondary_depth_conjunct (x2 s)) ` (x1 \<inter> {s. \<not> is_pos (x2 s)})) \<le> (SUP s\<in>x1. max_pos_conj_depth_conjunct (x2 s))"
+  then have "(SUP z\<in>x1. if is_pos (x2 z) then modal_depth_srbb_inner (un_Pos (x2 z)) else max_pos_conj_secondary_depth_conjunct (x2 z)) \<le> (SUP z\<in>x1. max_pos_conj_depth_conjunct (x2 z))"
+    using a1 by (smt (z3) hml_srbb_conjunct.collapse(1) max_pos_conj_depth_conjunct.simps(1) nle_le rangeI)
+  then show "Sup ((\<lambda>z. modal_depth_srbb_inner (un_Pos (x2 z))) ` (x1 \<inter> {z. is_pos (x2 z)}) \<union> (\<lambda>z. max_pos_conj_secondary_depth_conjunct (x2 z)) ` (x1 \<inter> {z. \<not> is_pos (x2 z)})) \<le> (SUP z\<in>x1. max_pos_conj_depth_conjunct (x2 z))"
     by simp
 qed
   
@@ -1260,6 +1259,48 @@ proof
   qed
 qed
 
+lemma distinction_conjunctification_opt_price:
+  assumes
+    \<open>\<forall>q\<in>I. distinguishes (\<Phi> q) p q\<close>
+    \<open>\<forall>q\<in>I. \<Phi> q \<in> \<O> pr\<close>
+    \<open>modal_depth pr \<le> pos_conjuncts pr\<close>
+  shows
+    \<open>\<forall>q\<in>I. ((conjunctify_distinctions_opt \<Phi> p) (Some q)) \<in> \<O>_conjunct pr\<close>
+proof
+  fix q
+  assume \<open>q \<in> I\<close>
+  show \<open>conjunctify_distinctions_opt \<Phi> p (Some q) \<in> \<O>_conjunct pr\<close>
+  proof (cases \<open>\<Phi> q\<close>)
+    case TT
+    then show ?thesis
+      using assms \<open>q \<in> I\<close>
+      by fastforce
+  next
+    case (Internal \<chi>)
+    then show ?thesis
+      using assms \<open>q \<in> I\<close>
+      unfolding conjunctify_distinctions_opt_def \<O>_def \<O>_conjunct_def
+      by fastforce
+  next
+    case (ImmConj J \<Psi>)
+    hence \<open>\<exists>i. i\<in>J \<and> hml_srbb_conj.distinguishes (\<Psi> i) p q\<close>
+      using \<open>q \<in> I\<close> assms(1) by fastforce
+    moreover have \<open>conjunctify_distinctions_opt \<Phi> p (Some q)  = \<Psi> (SOME i. i\<in>J \<and> hml_srbb_conj.distinguishes (\<Psi> i) p q)\<close>
+      unfolding conjunctify_distinctions_opt_def using ImmConj by fastforce
+    ultimately have \<Psi>_i: \<open>\<exists>i\<in>J. hml_srbb_conj.distinguishes (\<Psi> i) p q \<and> conjunctify_distinctions_opt \<Phi> p (Some q) = \<Psi> i\<close>
+      by (metis (no_types, lifting) some_eq_ex)
+    hence \<open>conjunctify_distinctions_opt \<Phi> p (Some q) \<in> \<Psi>`J\<close>
+      unfolding image_iff by blast
+    hence \<open>expr_pr_conjunct (conjunctify_distinctions_opt \<Phi> p (Some q)) \<le> expressiveness_price (ImmConj J \<Psi>)\<close>
+      by (smt (verit, best) \<Psi>_i dual_order.trans expressiveness_price_ImmConj_geq_parts gets_smaller)
+    then show ?thesis
+      using assms \<open>q \<in> I\<close> ImmConj
+      unfolding \<O>_def \<O>_conjunct_def
+      by auto
+  qed
+qed
+
+
 lemma modal_stability_respecting:
   assumes
     \<open>0 < e9\<close>
@@ -1282,30 +1323,30 @@ proof safe
     hence distinctions:
       \<open>\<forall>q'\<in>(silent_reachable_set {q} \<inter> {q'. stable_state q'}). distinguishes (\<Phi> q') p q'\<close>
       \<open>\<forall>q'\<in>(silent_reachable_set {q} \<inter> {q'. stable_state q'}). \<Phi> q' \<in> \<O> (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)\<close> by blast+
-    from distinction_conjunctification_price[OF this] have
-      \<open>\<forall>q'\<in>(silent_reachable_set {q} \<inter> {q'. stable_state q'}). conjunctify_distinctions \<Phi> p q' \<in> \<O>_conjunct (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)\<close>
-      by fastforce
-    hence conj_price: \<open>StableConj (silent_reachable_set {q} \<inter> {q'. stable_state q'}) (conjunctify_distinctions \<Phi> p)
+    from distinction_conjunctification_opt_price[OF this] have
+      \<open>\<forall>q'\<in>(silent_reachable_set {q} \<inter> {q'. stable_state q'}). conjunctify_distinctions_opt \<Phi> p (Some q') \<in> \<O>_conjunct (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)\<close>
+      by auto
+    hence conj_price: \<open>StableConj (Some ` (silent_reachable_set {q} \<inter> {q'. stable_state q'})) (conjunctify_distinctions_opt \<Phi> p)
         \<in> \<O>_inner (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)\<close>
       unfolding \<O>_inner_def \<O>_conjunct_def using SUP_le_iff ileI1[OF \<open>0 < e9\<close>] one_eSuc
       by (fastforce simp add: SUP_le_iff)
     from \<Phi>_def have
       \<open>\<forall>q'\<in>(silent_reachable_set {q}). stable_state q' \<longrightarrow>
-         hml_srbb_conj.distinguishes (conjunctify_distinctions \<Phi> p q') p q'\<close>
-      using singleton_iff distinction_conjunctification by metis
+         hml_srbb_conj.distinguishes (conjunctify_distinctions_opt \<Phi> p (Some q')) p q'\<close>
+      using singleton_iff distinction_conjunctification_opt by metis
     hence \<open>hml_srbb_inner.distinguishes_from
-       (StableConj (silent_reachable_set {q} \<inter> {q'. stable_state q'}) (conjunctify_distinctions \<Phi> p))
+       (StableConj (Some ` (silent_reachable_set {q} \<inter> {q'. stable_state q'})) (conjunctify_distinctions_opt \<Phi> p))
        p (silent_reachable_set {q})\<close>
       using p_stability(2) by fastforce
     hence
       \<open>distinguishes
-        (Internal (StableConj (silent_reachable_set {q} \<inter> {q'. stable_state q'})
-                (conjunctify_distinctions \<Phi> p)))
+        (Internal (StableConj (Some ` (silent_reachable_set {q} \<inter> {q'. stable_state q'}))
+                (conjunctify_distinctions_opt \<Phi> p)))
         p q\<close>
       unfolding silent_reachable_set_def
       using silent_reachable.refl by auto
     moreover have
-      \<open>Internal (StableConj (silent_reachable_set {q} \<inter> {q'. stable_state q'}) (conjunctify_distinctions \<Phi> p))
+      \<open>Internal (StableConj (Some ` (silent_reachable_set {q} \<inter> {q'. stable_state q'})) (conjunctify_distinctions_opt \<Phi> p))
         \<in> \<O> (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)\<close>
       using conj_price unfolding \<O>_def \<O>_inner_def by simp
     ultimately show False

--- a/Expressiveness_Price.thy
+++ b/Expressiveness_Price.thy
@@ -656,7 +656,6 @@ qed
 lemma expr_st_conj:
   assumes
     \<open>subtract_fn  0 0 0 1 0 0 0 0 0 e = Some e'\<close>
-    \<open>I \<noteq> {}\<close>
     \<open>\<forall>q \<in> I. expr_pr_conjunct (\<psi>s q) \<le> e'\<close>
     \<open>\<forall>q \<in> I - revival_conjunct_index I \<psi>s. is_pos (\<psi>s q) \<longrightarrow> modal_depth_srbb_conjunct (\<psi>s q) \<le> pos_conjuncts_sec e'\<close>
     \<open>0 < neg_depth e\<close>

--- a/Expressiveness_Price.thy
+++ b/Expressiveness_Price.thy
@@ -278,7 +278,7 @@ lemma modal_depth_dominates_pos_conjuncts:
   by (auto simp add: SUP_mono' add_increasing sup.coboundedI1 sup.coboundedI2)
 
 \<comment>\<open>Supremum after some maximal element has been removed\<close>
-definition revival_conjunct_index :: \<open>'s option set \<Rightarrow> ('s option \<Rightarrow> ('a, 's) hml_srbb_conjunct) \<Rightarrow> 's option set\<close> where
+definition revival_conjunct_index :: \<open>'x option set \<Rightarrow> ('x option \<Rightarrow> ('a, 's) hml_srbb_conjunct) \<Rightarrow> 'x option set\<close> where
   \<open>revival_conjunct_index I \<psi>s \<equiv>
     if (\<exists>i\<in>I. is_pos (\<psi>s i) \<and> (\<forall>j\<in>I. is_pos (\<psi>s j) \<longrightarrow>
         modal_depth_srbb_conjunct (\<psi>s j) \<le> modal_depth_srbb_conjunct (\<psi>s i))) then

--- a/Expressiveness_Price.thy
+++ b/Expressiveness_Price.thy
@@ -277,6 +277,85 @@ lemma modal_depth_dominates_pos_conjuncts:
         \<open>\<lambda>\<psi>. max_pos_conj_depth_conjunct \<psi> \<le> modal_depth_srbb_conjunct \<psi>\<close>]
   by (auto simp add: SUP_mono' add_increasing sup.coboundedI1 sup.coboundedI2)
 
+\<comment>\<open>Supremum after some maximal element has been removed\<close>
+definition revival_conjunct_index :: \<open>'s set \<Rightarrow> ('s \<Rightarrow> ('a, 's) hml_srbb_conjunct) \<Rightarrow> 's set\<close> where
+  \<open>revival_conjunct_index I \<psi>s \<equiv>
+    if (\<exists>i\<in>I. is_pos (\<psi>s i) \<and> (\<forall>j\<in>I. is_pos (\<psi>s j) \<longrightarrow>
+        modal_depth_srbb_conjunct (\<psi>s j) \<le> modal_depth_srbb_conjunct (\<psi>s i))) then
+      {SOME i. i\<in>I \<and> is_pos (\<psi>s i) \<and> (\<forall>j\<in>I. is_pos (\<psi>s j) \<longrightarrow>
+        modal_depth_srbb_conjunct (\<psi>s j) \<le> modal_depth_srbb_conjunct (\<psi>s i))}
+    else {}\<close>
+
+
+(*lemma
+  assumes \<open>\<exists>j\<in>I. is_pos (\<psi>s j)\<close>
+  shows \<open>\<exists>r\<in>I. (revival_conjunct_index I \<psi>s) = {r} \<and> is_pos (\<psi>s r) \<and> 
+    (\<forall>j\<in>I. is_pos (\<psi>s j) \<longrightarrow> modal_depth_srbb_conjunct (\<psi>s j) \<le> modal_depth_srbb_conjunct (\<psi>s r))\<close>
+proof -
+  from assms obtain r where
+    \<open>r\<in>I\<close> \<open>is_pos (\<psi>s r)\<close> \<open>modal_depth_srbb_conjunct (\<psi>s r) = (Sup {modal_depth_srbb_conjunct (\<psi>s j)| j. j\<in>I \<and> is_pos (\<psi>s j)})\<close>
+    sledgehammer
+  hence
+    \<open>(\<forall>j\<in>I. is_pos (\<psi>s j) \<longrightarrow>
+        modal_depth_srbb_conjunct (\<psi>s j) \<le> modal_depth_srbb_conjunct (\<psi>s r))\<close>
+    sledgehammer
+*)
+  
+primrec
+      max_positive_conjunct_secondary_depth :: \<open>('a, 's) hml_srbb \<Rightarrow> enat\<close>
+  and max_pos_conj_secondary_depth_inner :: \<open>('a, 's) hml_srbb_inner \<Rightarrow> enat\<close>
+  and max_pos_conj_secondary_depth_conjunct :: \<open>('a, 's) hml_srbb_conjunct \<Rightarrow> enat\<close> where
+  \<open>max_positive_conjunct_secondary_depth TT = 0\<close> |
+  \<open>max_positive_conjunct_secondary_depth (Internal \<chi>) = max_pos_conj_secondary_depth_inner \<chi>\<close> |
+  \<open>max_positive_conjunct_secondary_depth (ImmConj I \<psi>s) = Sup ((max_pos_conj_secondary_depth_conjunct \<circ> \<psi>s) ` I)\<close> |
+
+  \<open>max_pos_conj_secondary_depth_inner (Obs _ \<phi>) = max_positive_conjunct_secondary_depth \<phi>\<close> |
+  \<open>max_pos_conj_secondary_depth_inner (Conj I \<psi>s) = 
+    Sup ((max_pos_conj_secondary_depth_conjunct \<circ> \<psi>s) ` I)\<close> |
+  \<open>max_pos_conj_secondary_depth_inner (StableConj I \<psi>s) =
+    Sup (((\<lambda>\<psi>. case \<psi> of (Pos \<chi>) \<Rightarrow> modal_depth_srbb_inner \<chi> | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct \<psi>) \<circ> \<psi>s)
+     ` (I - (revival_conjunct_index I \<psi>s)))\<close> |
+  \<open>max_pos_conj_secondary_depth_inner (BranchConj _ \<phi> I \<psi>s) =
+    Sup ({max_positive_conjunct_secondary_depth \<phi>} \<union> ((max_pos_conj_secondary_depth_conjunct \<circ> \<psi>s) ` I))\<close> |
+
+  \<open>max_pos_conj_secondary_depth_conjunct (Pos \<chi>) = max_pos_conj_secondary_depth_inner \<chi>\<close> |
+  \<open>max_pos_conj_secondary_depth_conjunct (Neg \<chi>) = max_pos_conj_secondary_depth_inner \<chi>\<close>
+
+(* 
+  and max_pos_stable_conj_secondary_depth_conjunct :: \<open>('a, 's) hml_srbb_conjunct \<Rightarrow> enat\<close>
+
+  \<open>max_pos_stable_conj_secondary_depth_conjunct (Pos \<chi>) = modal_depth_srbb_inner \<chi>\<close> |
+  \<open>max_pos_stable_conj_secondary_depth_conjunct (Neg \<chi>) = max_pos_conj_secondary_depth_inner \<chi>\<close>*)
+
+lemma modal_depth_srbb_rewrite: \<open>modal_depth_srbb_inner \<chi> = modal_depth_srbb_conjunct (Pos \<chi>)\<close>
+  by simp
+
+lemma max_positive_conjunct_depth_dominates_secondary:
+  fixes
+    \<phi>::\<open>('a, 's) hml_srbb\<close> and
+    \<chi>::\<open>('a, 's) hml_srbb_inner\<close> and
+    \<psi>::\<open>('a, 's) hml_srbb_conjunct\<close>
+  shows
+    \<open>max_positive_conjunct_secondary_depth \<phi> \<le> max_positive_conjunct_depth \<phi>\<close>
+    \<open>max_pos_conj_secondary_depth_inner \<chi> \<le> max_pos_conj_depth_inner \<chi>\<close>
+    \<open>max_pos_conj_secondary_depth_conjunct \<psi> \<le> max_pos_conj_depth_conjunct \<psi>\<close>
+    apply (induct \<phi> and \<chi> and \<psi>)
+          apply   (auto simp add: SUP_mono' revival_conjunct_index_def Sup_subset_mono image_mono le_supI1 le_supI2 SUP_subset_mono)
+    apply (smt (verit, ccfv_threshold) Diff_subset SUP_subset_mono hml_srbb_conjunct.case_eq_if hml_srbb_conjunct.simps(5) is_pos_def max_pos_conj_depth_conjunct.simps(1) nle_le rangeI)
+  apply (simp add: SUP_mono' hml_srbb_conjunct.case_eq_if) defer
+  using modal_depth_dominates_pos_conjuncts order_trans  apply blast
+proof -
+  fix x1 :: "'s set" and x2 :: "'s \<Rightarrow> ('a, 's) hml_srbb_conjunct"
+  assume a1: "\<And>x2a. x2a \<in> range x2 \<Longrightarrow> max_pos_conj_secondary_depth_conjunct x2a \<le> max_pos_conj_depth_conjunct x2a"
+  obtain ss :: "('s \<Rightarrow> enat) \<Rightarrow> ('s \<Rightarrow> enat) \<Rightarrow> 's" where
+    "\<And>f fa S. \<not> f (ss f fa) \<le> fa (ss f fa) \<or> Sup (f ` S) \<le> Sup (fa ` S)"
+    by (meson SUP_mono')
+  then have "(SUP s\<in>x1. if is_pos (x2 s) then modal_depth_srbb_inner (un_Pos (x2 s)) else max_pos_conj_secondary_depth_conjunct (x2 s)) \<le> (SUP s\<in>x1. max_pos_conj_depth_conjunct (x2 s))"
+    using a1 by (smt (z3) hml_srbb_conjunct.collapse(1) max_pos_conj_depth_conjunct.simps(1) modal_depth_dominates_pos_conjuncts modal_depth_srbb_rewrite rangeI)
+  then show "Sup ((\<lambda>s. modal_depth_srbb_inner (un_Pos (x2 s))) ` (x1 \<inter> {s. is_pos (x2 s)}) \<union> (\<lambda>s. max_pos_conj_secondary_depth_conjunct (x2 s)) ` (x1 \<inter> {s. \<not> is_pos (x2 s)})) \<le> (SUP s\<in>x1. max_pos_conj_depth_conjunct (x2 s))"
+    by simp
+qed
+  
 subsection \<open>Maximal Modal Depth of Negative Clauses in Conjunctions\<close>
 
 text \<open>
@@ -300,8 +379,6 @@ primrec
 
   \<open>max_neg_conj_depth_conjunct (Pos \<chi>) = max_neg_conj_depth_inner \<chi>\<close> |
   \<open>max_neg_conj_depth_conjunct (Neg \<chi>) = modal_depth_srbb_inner \<chi>\<close>
-
-
 
 lemma modal_depth_dominates_neg_conjuncts:
   fixes
@@ -354,6 +431,7 @@ fun expressiveness_price :: \<open>('a, 's) hml_srbb \<Rightarrow> energy\<close
                               (stable_conjunction_depth    \<phi>)
                               (immediate_conjunction_depth \<phi>)
                               (max_positive_conjunct_depth \<phi>)
+                              (max_positive_conjunct_secondary_depth \<phi>)
                               (max_negative_conjunct_depth \<phi>)
                               (negation_depth              \<phi>)\<close>
 
@@ -366,6 +444,7 @@ lemma expressiveness_price_ImmConj_def:
     (Sup ((st_conj_depth_conjunct \<circ> \<psi>s) ` I))
     (if I = {} then 0 else 1 + Sup ((imm_conj_depth_conjunct \<circ> \<psi>s) ` I))
     (Sup ((max_pos_conj_depth_conjunct \<circ> \<psi>s) ` I))
+    (Sup ((max_pos_conj_secondary_depth_conjunct \<circ> \<psi>s) ` I))
     (Sup ((max_neg_conj_depth_conjunct \<circ> \<psi>s) ` I))
     (Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I))\<close> by simp
 
@@ -378,19 +457,20 @@ lemma expressiveness_price_ImmConj_non_empty_def:
     (Sup ((st_conj_depth_conjunct \<circ> \<psi>s) ` I))
     (1 + Sup ((imm_conj_depth_conjunct \<circ> \<psi>s) ` I))
     (Sup ((max_pos_conj_depth_conjunct \<circ> \<psi>s) ` I))
+    (Sup ((max_pos_conj_secondary_depth_conjunct \<circ> \<psi>s) ` I))
     (Sup ((max_neg_conj_depth_conjunct \<circ> \<psi>s) ` I))
     (Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I))\<close> using assms  by simp
 
 lemma expressiveness_price_ImmConj_empty_def:
   assumes \<open>I = {}\<close>
-  shows \<open>expressiveness_price (ImmConj I \<psi>s) = E 0 0 0 0 0 0 0 0\<close> using assms
+  shows \<open>expressiveness_price (ImmConj I \<psi>s) = E 0 0 0 0 0 0 0 0 0\<close> using assms
   unfolding expressiveness_price_ImmConj_def by (simp add: bot_enat_def)
 
 text \<open>We can now define a sublanguage of Hennessy-Milner Logic @{term \<open>\<O>\<close>} by the set of formulas with prices below an energy coordinate.\<close>
 definition \<O> :: \<open>energy \<Rightarrow> (('a, 's) hml_srbb) set\<close> where
   \<open>\<O> energy \<equiv> {\<phi> . expressiveness_price \<phi> \<le> energy}\<close>
 
-lemma \<O>_sup: \<open>UNIV = \<O> (E \<infinity> \<infinity> \<infinity> \<infinity> \<infinity> \<infinity> \<infinity> \<infinity>)\<close> unfolding \<O>_def by auto
+lemma \<O>_sup: \<open>UNIV = \<O> (E \<infinity> \<infinity> \<infinity> \<infinity> \<infinity> \<infinity> \<infinity> \<infinity> \<infinity>)\<close> unfolding \<O>_def by auto
 
 text \<open>Formalizing HML$_{SRBB}$ by mutually recursive data types leads to expressiveness price functions of these other types,
 namely @{term \<open>expr_pr_inner\<close>} and @{term \<open>expr_pr_conjunct\<close>}, and corresponding definitions and lemmas.\<close>
@@ -402,6 +482,7 @@ fun expr_pr_inner :: \<open>('a, 's) hml_srbb_inner \<Rightarrow> energy\<close>
                  (st_conj_depth_inner \<chi>)
                  (imm_conj_depth_inner \<chi>)
                  (max_pos_conj_depth_inner \<chi>)
+                 (max_pos_conj_secondary_depth_inner \<chi>)
                  (max_neg_conj_depth_inner \<chi>)
                  (neg_depth_inner \<chi>)\<close>
 
@@ -415,6 +496,7 @@ fun expr_pr_conjunct :: \<open>('a, 's) hml_srbb_conjunct \<Rightarrow> energy\<
                  (st_conj_depth_conjunct \<psi>)
                  (imm_conj_depth_conjunct \<psi>)
                  (max_pos_conj_depth_conjunct \<psi>)
+                 (max_pos_conj_secondary_depth_conjunct \<psi>)
                  (max_neg_conj_depth_conjunct \<psi>)
                  (neg_depth_conjunct \<psi>)\<close>
 
@@ -434,34 +516,16 @@ text \<open>For example, here, we establish that the expressiveness price of \<o
 
 lemma expr_internal_eq:
   shows \<open>expressiveness_price (Internal \<chi>) = expr_pr_inner \<chi>\<close>
-proof-
-  have expr_internal: \<open>expressiveness_price (Internal \<chi>) = E (modal_depth_srbb (Internal \<chi>))
-                              (branching_conjunction_depth (Internal \<chi>))
-                              (unstable_conjunction_depth  (Internal \<chi>))
-                              (stable_conjunction_depth    (Internal \<chi>))
-                              (immediate_conjunction_depth (Internal \<chi>))
-                              (max_positive_conjunct_depth (Internal \<chi>))
-                              (max_negative_conjunct_depth (Internal \<chi>))
-                              (negation_depth              (Internal \<chi>))\<close>
-            using expressiveness_price.simps by blast
-          have \<open>modal_depth_srbb (Internal \<chi>) = modal_depth_srbb_inner \<chi>\<close>
-            \<open>(branching_conjunction_depth (Internal \<chi>)) = branch_conj_depth_inner \<chi>\<close>
-            \<open>(unstable_conjunction_depth  (Internal \<chi>)) = inst_conj_depth_inner \<chi>\<close>
-            \<open>(stable_conjunction_depth    (Internal \<chi>)) = st_conj_depth_inner \<chi>\<close>
-            \<open>(immediate_conjunction_depth (Internal \<chi>)) = imm_conj_depth_inner \<chi>\<close>
-            \<open>max_positive_conjunct_depth (Internal \<chi>) = max_pos_conj_depth_inner \<chi>\<close>
-            \<open>max_negative_conjunct_depth (Internal \<chi>) = max_neg_conj_depth_inner \<chi>\<close>
-            \<open>negation_depth (Internal \<chi>) = neg_depth_inner \<chi>\<close>
-            by simp+
-          with expr_internal show ?thesis
-            by auto
-        qed
+  by auto
 
-text \<open>If the price of a formula \<open>\<chi>\<close> is not greater than the minimum update @{term \<open>min1_6\<close>} apllied to some energy $e$,
+text \<open>If the price of a formula \<open>\<chi>\<close> is not greater than the minimum update @{term \<open>min1_7\<close>} applied to some energy $e$,
 then \<open>Pos \<chi>\<close> is not greater than \<open>e\<close>.\<close>
 lemma expr_pos:
-  assumes \<open>expr_pr_inner \<chi> \<le> the (min1_6 e)\<close>
-  shows \<open>expr_pr_conjunct (Pos \<chi>) \<le> e\<close>
+  assumes
+    \<open>expr_pr_inner \<chi> \<le> the (min1_7 e)\<close>
+    \<open>pos_conjuncts_sec e \<le> pos_conjuncts e\<close>
+  shows
+    \<open>expr_pr_conjunct (Pos \<chi>) \<le> e\<close>
 proof-
   have expr_internal: \<open>expr_pr_conjunct (Pos \<chi>) = E (modal_depth_srbb_conjunct (Pos \<chi>))
                               (branch_conj_depth_conjunct (Pos \<chi>))
@@ -469,6 +533,7 @@ proof-
                               (st_conj_depth_conjunct    (Pos \<chi>))
                               (imm_conj_depth_conjunct (Pos \<chi>))
                               (max_pos_conj_depth_conjunct (Pos \<chi>))
+                              (max_pos_conj_secondary_depth_conjunct (Pos \<chi>))
                               (max_neg_conj_depth_conjunct (Pos \<chi>))
                               (neg_depth_conjunct            (Pos \<chi>))\<close>
             using expr_pr_conjunct.simps by blast
@@ -478,25 +543,26 @@ proof-
                 \<open>(st_conj_depth_conjunct    (Pos \<chi>)) = st_conj_depth_inner \<chi>\<close>
                 \<open>(imm_conj_depth_conjunct (Pos \<chi>)) = imm_conj_depth_inner \<chi>\<close>
                 \<open>(max_pos_conj_depth_conjunct (Pos \<chi>)) = modal_depth_srbb_inner \<chi>\<close>
+                \<open>(max_pos_conj_secondary_depth_conjunct (Pos \<chi>)) = max_pos_conj_secondary_depth_inner \<chi>\<close>
                 \<open>(max_neg_conj_depth_conjunct (Pos \<chi>)) = max_neg_conj_depth_inner \<chi>\<close>
                 \<open>(neg_depth_conjunct            (Pos \<chi>)) = neg_depth_inner \<chi>\<close>
     by simp+
-  obtain e1 e2 e3 e4 e5 e6 e7 e8 where \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8\<close>
+  obtain e1 e2 e3 e4 e5 e6 e7 e8 e9 where \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8 e9\<close>
     by (metis energy.exhaust_sel)
-  hence \<open>min1_6 e = Some (E (min e1 e6) e2 e3 e4 e5 e6 e7 e8)\<close>
-    by (simp add: min1_6_def)
-  hence \<open>modal_depth_srbb_inner \<chi> \<le> (min e1 e6)\<close>
+  hence \<open>min1_7 e = Some (E (min e1 e7) e2 e3 e4 e5 e6 e7 e8 e9)\<close>
+    by (simp add: min1_7_def)
+  hence \<open>modal_depth_srbb_inner \<chi> \<le> (min e1 e7)\<close>
     using assms leq_components by fastforce
-  hence \<open>modal_depth_srbb_inner \<chi> \<le> e6\<close>
+  hence \<open>modal_depth_srbb_inner \<chi> \<le> e7\<close>
     using min.boundedE by blast
   thus \<open>expr_pr_conjunct (Pos \<chi>) \<le> e\<close>
-    using expr_internal pos_upd \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8\<close> assms leq_components by auto
+    using expr_internal pos_upd \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8 e9\<close> assms leq_components by auto
 qed
 
 lemma expr_neg:
   assumes
     \<open>expr_pr_inner \<chi> \<le> e'\<close>
-    \<open>(Option.bind ((subtract_fn 0 0 0 0 0 0 0 1) e) min1_7) = Some e'\<close>
+    \<open>(Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8) = Some e'\<close>
   shows \<open>expr_pr_conjunct (Neg \<chi>) \<le> e\<close>
 proof-
   have expr_neg: \<open>expr_pr_conjunct (Neg \<chi>) =
@@ -506,6 +572,7 @@ proof-
       (st_conj_depth_conjunct (Neg \<chi>))
       (imm_conj_depth_conjunct (Neg \<chi>))
       (max_pos_conj_depth_conjunct (Neg \<chi>))
+      (max_pos_conj_secondary_depth_conjunct (Neg \<chi>))
       (max_neg_conj_depth_conjunct (Neg \<chi>))
       (neg_depth_conjunct (Neg \<chi>))\<close>
     using expr_pr_conjunct.simps by blast
@@ -516,33 +583,34 @@ proof-
     \<open>st_conj_depth_conjunct (Neg \<chi>) = st_conj_depth_inner \<chi>\<close>
     \<open>imm_conj_depth_conjunct (Neg \<chi>) = imm_conj_depth_inner \<chi>\<close>
     \<open>max_pos_conj_depth_conjunct (Neg \<chi>) = max_pos_conj_depth_inner \<chi>\<close>
+    \<open>max_pos_conj_secondary_depth_conjunct (Neg \<chi>) = max_pos_conj_secondary_depth_inner \<chi>\<close>
     \<open>max_neg_conj_depth_conjunct (Neg \<chi>) = modal_depth_srbb_inner \<chi>\<close>
     \<open>neg_depth_conjunct (Neg \<chi>) = 1 + neg_depth_inner \<chi>\<close>
     by simp+
-  obtain e1 e2 e3 e4 e5 e6 e7 e8 where e_def: \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8\<close>
+  obtain e1 e2 e3 e4 e5 e6 e7 e8 e9 where e_def: \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8 e9\<close>
     by (metis energy.exhaust_sel)
-  hence is_some: \<open>(subtract_fn 0 0 0 0 0 0 0 1 e = Some (E e1 e2 e3 e4 e5 e6 e7 (e8-1)))\<close>
+  hence is_some: \<open>(subtract_fn 0 0 0 0 0 0 0 0 1 e = Some (E e1 e2 e3 e4 e5 e6 e7 e8 (e9-1)))\<close>
     using assms bind_eq_None_conv by fastforce
-  hence \<open>modal_depth_srbb_inner \<chi> \<le> (min e1 e7)\<close>
-    using assms expr_pr_inner.simps leq_components min_1_7_subtr_simp e_def
-    by (metis energy.sel(1) energy.sel(7) option.discI option.inject)
-  moreover have \<open>neg_depth_inner \<chi> \<le> (e8-1)\<close>
-    using e_def is_some energy_minus leq_components min_1_7_simps assms
-    by (smt (verit, ccfv_threshold) bind.bind_lunit energy.sel(8) expr_pr_inner.simps option.sel)
-  moreover hence \<open>neg_depth_conjunct (Neg \<chi>) \<le> e8\<close>
+  hence \<open>modal_depth_srbb_inner \<chi> \<le> (min e1 e8)\<close>
+    using assms expr_pr_inner.simps leq_components min_1_8_subtr_simp e_def
+    by (metis energy.sel(1) energy.sel(8) option.discI option.inject)
+  moreover have \<open>neg_depth_inner \<chi> \<le> (e9-1)\<close>
+    using e_def is_some energy_minus leq_components min_1_8_simps assms
+    by (smt (verit, ccfv_threshold) bind.bind_lunit energy.sel(9) expr_pr_inner.simps option.sel)
+  moreover hence \<open>neg_depth_conjunct (Neg \<chi>) \<le> e9\<close>
     using \<open>neg_depth_conjunct (Neg \<chi>) = 1 + neg_depth_inner \<chi>\<close>
     by (metis is_some add_diff_assoc_enat add_diff_cancel_enat e_def enat.simps(3)
-        enat_defs(2) enat_diff_mono energy.sel(8) leq_components linorder_not_less
+        enat_defs(2) enat_diff_mono energy.sel(9) leq_components linorder_not_less
         option.distinct(1) order_le_less)
   ultimately show \<open>expr_pr_conjunct (Neg \<chi>) \<le> e\<close>
-    using expr_neg e_def is_some assms neg_ups assms leq_components min_1_7_subtr_simp
+    using expr_neg e_def is_some assms neg_ups assms leq_components min_1_8_subtr_simp
     by (metis energy.sel expr_pr_inner.simps min.bounded_iff option.distinct(1) option.inject)
 qed
 
 lemma expr_obs:
   assumes
     \<open>expressiveness_price \<phi> \<le> e'\<close>
-    \<open>subtract_fn 1 0 0 0 0 0 0 0 e = Some e'\<close>
+    \<open>subtract_fn 1 0 0 0 0 0 0 0 0 e = Some e'\<close>
   shows \<open>expr_pr_inner (Obs \<alpha> \<phi>) \<le> e\<close>
 proof-
   have expr_pr_obs:
@@ -553,6 +621,7 @@ proof-
       (st_conj_depth_inner (Obs \<alpha> \<phi>))
       (imm_conj_depth_inner (Obs \<alpha> \<phi>))
       (max_pos_conj_depth_inner (Obs \<alpha> \<phi>))
+      (max_pos_conj_secondary_depth_inner (Obs \<alpha> \<phi>))
       (max_neg_conj_depth_inner (Obs \<alpha> \<phi>))
       (neg_depth_inner (Obs \<alpha> \<phi>)))\<close>
     using expr_pr_inner.simps by blast
@@ -562,13 +631,13 @@ proof-
     \<open>inst_conj_depth_inner (Obs \<alpha> \<phi>) = unstable_conjunction_depth \<phi>\<close>
     \<open>st_conj_depth_inner (Obs \<alpha> \<phi>) = stable_conjunction_depth \<phi>\<close>
     \<open>imm_conj_depth_inner (Obs \<alpha> \<phi>) = immediate_conjunction_depth \<phi>\<close>
-    \<open>max_pos_conj_depth_inner (Obs \<alpha> \<phi>) = max_positive_conjunct_depth \<phi>\<close>
+    \<open>max_pos_conj_secondary_depth_inner (Obs \<alpha> \<phi>) = max_positive_conjunct_secondary_depth \<phi>\<close>
     \<open>max_neg_conj_depth_inner (Obs \<alpha> \<phi>) = max_negative_conjunct_depth \<phi>\<close>
     \<open>neg_depth_inner (Obs \<alpha> \<phi>) = negation_depth \<phi>\<close>
     by simp_all
-  obtain e1 e2 e3 e4 e5 e6 e7 e8 where e_def: \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8\<close>
+  obtain e1 e2 e3 e4 e5 e6 e7 e8 e9 where e_def: \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8 e9\<close>
     by (metis energy.exhaust_sel)
-  then have is_some: \<open>(subtract_fn 1 0 0 0 0 0 0 0 e = Some (E (e1-1) e2 e3 e4 e5 e6 e7 e8))\<close>
+  then have is_some: \<open>(subtract_fn 1 0 0 0 0 0 0 0 0 e = Some (E (e1-1) e2 e3 e4 e5 e6 e7 e8 e9))\<close>
     using energy_minus idiff_0_right assms
     by (metis option.discI)
   hence \<open>modal_depth_srbb \<phi> \<le> (e1 - 1)\<close>
@@ -587,9 +656,10 @@ qed
 
 lemma expr_st_conj:
   assumes
-    \<open>subtract_fn  0 0 0 1 0 0 0 0 e = Some e'\<close>
+    \<open>subtract_fn  0 0 0 1 0 0 0 0 0 e = Some e'\<close>
     \<open>I \<noteq> {}\<close>
     \<open>\<forall>q \<in> I. expr_pr_conjunct (\<psi>s q) \<le> e'\<close>
+    \<open>pos_conjuncts_sec e' \<le> modal_depth e'\<close>
   shows
     \<open>expr_pr_inner (StableConj I \<psi>s) \<le> e\<close>
 proof -
@@ -600,24 +670,30 @@ proof -
     \<open>st_conj_depth_inner (StableConj I \<psi>s) = 1 + Sup ((st_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>imm_conj_depth_inner (StableConj I \<psi>s) = Sup ((imm_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>max_pos_conj_depth_inner (StableConj I \<psi>s) = Sup ((max_pos_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
+    \<open>max_pos_conj_secondary_depth_inner (StableConj I \<psi>s) = 
+      Sup (((\<lambda>\<psi>. case \<psi> of (Pos \<chi>) \<Rightarrow> modal_depth_srbb_inner \<chi> | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct \<psi>) \<circ> \<psi>s)
+        ` (I - (revival_conjunct_index I \<psi>s)))\<close>
     \<open>max_neg_conj_depth_inner (StableConj I \<psi>s) = Sup ((max_neg_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>neg_depth_inner (StableConj I \<psi>s) = Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     by force+
-  obtain e1 e2 e3 e4 e5 e6 e7 e8 where e_def: \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8\<close>
+  obtain e1 e2 e3 e4 e5 e6 e7 e8 e9 where e_def: \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8 e9\<close>
     using energy.exhaust_sel by blast
-  hence is_some: \<open>subtract_fn  0 0 0 1 0 0 0 0 e = Some (E e1 e2 e3 (e4-1) e5 e6 e7 e8)\<close>
+  hence is_some: \<open>subtract_fn  0 0 0 1 0 0 0 0 0 e = Some (E e1 e2 e3 (e4-1) e5 e6 e7 e8 e9)\<close>
     using assms minus_energy_def
     by (smt (verit, del_insts) energy_minus idiff_0_right option.distinct(1))
-  hence
+  hence min_e1_e7: \<open>min e1 e7 = e7\<close> using is_some assms by auto
+  from is_some have
     \<open>\<forall>i \<in> I. modal_depth_srbb_conjunct (\<psi>s i) \<le> e1\<close>
     \<open>\<forall>i \<in> I. branch_conj_depth_conjunct (\<psi>s i) \<le> e2\<close>
     \<open>\<forall>i \<in> I. inst_conj_depth_conjunct (\<psi>s i) \<le> e3\<close>
     \<open>\<forall>i \<in> I. st_conj_depth_conjunct (\<psi>s i) \<le> (e4 - 1)\<close>
     \<open>\<forall>i \<in> I. imm_conj_depth_conjunct (\<psi>s i) \<le> e5\<close>
     \<open>\<forall>i \<in> I. max_pos_conj_depth_conjunct (\<psi>s i) \<le> e6\<close>
-    \<open>\<forall>i \<in> I. max_neg_conj_depth_conjunct (\<psi>s i) \<le> e7\<close>
-    \<open>\<forall>i \<in> I. neg_depth_conjunct (\<psi>s i) \<le> e8\<close>
-    using assms unfolding leq_components by auto
+    \<open>\<forall>i \<in> I. max_pos_conj_secondary_depth_conjunct (\<psi>s i) \<le> e7\<close>
+    \<open>\<forall>i \<in> I. max_neg_conj_depth_conjunct (\<psi>s i) \<le> e8\<close>
+    \<open>\<forall>i \<in> I. neg_depth_conjunct (\<psi>s i) \<le> e9\<close>
+    using assms unfolding leq_components
+    by auto
   hence sups:
     \<open>Sup ((modal_depth_srbb_conjunct \<circ> \<psi>s) ` I) \<le> e1\<close>
     \<open>Sup ((branch_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> e2\<close>
@@ -625,20 +701,26 @@ proof -
     \<open>Sup ((st_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> (e4 - 1)\<close>
     \<open>Sup ((imm_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> e5\<close>
     \<open>Sup ((max_pos_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> e6\<close>
-    \<open>Sup ((max_neg_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> e7\<close>
-    \<open>Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I) \<le> e8\<close>
+    \<open>Sup ((max_pos_conj_secondary_depth_conjunct \<circ> \<psi>s) ` I) \<le> e7\<close>
+    \<open>Sup ((max_neg_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> e8\<close>
+    \<open>Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I) \<le> e9\<close>
     by (simp add: Sup_le_iff)+
   hence \<open>st_conj_depth_inner (StableConj I \<psi>s) \<le> e4\<close>
     using e_def is_some minus_energy_def leq_components st_conj_upds(4)
     by (metis add_diff_cancel_enat add_left_mono enat.simps(3) enat_defs(2) energy.sel(4) le_iff_add option.distinct(1))
-  then show ?thesis
-    using st_conj_upds sups
-    by (simp add: e_def)
+  moreover have \<open>\<forall>i \<in> I. i \<notin> revival_conjunct_index I \<psi>s \<longrightarrow>
+    (case \<psi>s i of Pos \<chi> \<Rightarrow> modal_depth_srbb_inner \<chi> | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct (\<psi>s i)) \<le> e7\<close>
+    using sups st_conj_upds unfolding e_def revival_conjunct_index_def max_def
+    sorry
+  ultimately show ?thesis
+    using st_conj_upds sups \<open>subtract_fn  0 0 0 1 0 0 0 0 0 e = Some e'\<close>
+    unfolding e_def
+    by (auto simp add:  SUP_le_iff)    
 qed
 
 lemma expr_imm_conj:
   assumes
-    \<open>subtract_fn  0 0 0 0 1 0 0 0 e = Some e'\<close>
+    \<open>subtract_fn  0 0 0 0 1 0 0 0 0 e = Some e'\<close>
     \<open>I \<noteq> {}\<close>
     \<open>expr_pr_inner (Conj I \<psi>s) \<le> e'\<close>
   shows \<open>expressiveness_price (ImmConj I \<psi>s) \<le> e\<close>
@@ -650,6 +732,7 @@ proof-
     \<open>st_conj_depth_inner (Conj I \<psi>s) = Sup ((st_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>imm_conj_depth_inner (Conj I \<psi>s) = Sup ((imm_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>max_pos_conj_depth_inner (Conj I \<psi>s) = Sup ((max_pos_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
+    \<open>max_pos_conj_secondary_depth_inner (Conj I \<psi>s) = Sup ((max_pos_conj_secondary_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>max_neg_conj_depth_inner (Conj I \<psi>s) = Sup ((max_neg_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>neg_depth_inner (Conj I \<psi>s) = Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     using assms
@@ -661,16 +744,17 @@ proof-
     \<open>stable_conjunction_depth (ImmConj I \<psi>s) = Sup ((st_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>immediate_conjunction_depth (ImmConj I \<psi>s) = 1 + Sup ((imm_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>max_positive_conjunct_depth (ImmConj I \<psi>s) = Sup ((max_pos_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
+    \<open>max_positive_conjunct_secondary_depth (ImmConj I \<psi>s) = Sup ((max_pos_conj_secondary_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>max_negative_conjunct_depth (ImmConj I \<psi>s) = Sup ((max_neg_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>negation_depth (ImmConj I \<psi>s) = Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     using assms
     by force+
-  obtain e1 e2 e3 e4 e5 e6 e7 e8 where e_def: \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8\<close>
+  obtain e1 e2 e3 e4 e5 e6 e7 e8 e9 where e_def: \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8 e9\<close>
     using assms by (metis energy.exhaust_sel)
-  hence is_some: \<open>(e - (E 0 0 0 0 1 0 0 0)) = (E e1 e2 e3 e4 (e5-1) e6 e7 e8)\<close>
+  hence is_some: \<open>(e - (E 0 0 0 0 1 0 0 0 0)) = (E e1 e2 e3 e4 (e5-1) e6 e7 e8 e9)\<close>
     using minus_energy_def
     by simp
-  hence \<open>e5>0\<close> using assms(1) e_def leq_components by auto
+  hence \<open>e5 > 0\<close> using assms(1) e_def leq_components by auto
   have
     \<open>E (modal_depth_srbb_inner (Conj I \<psi>s))
        (branch_conj_depth_inner (Conj I \<psi>s))
@@ -678,8 +762,9 @@ proof-
        (st_conj_depth_inner (Conj I \<psi>s))
        (imm_conj_depth_inner (Conj I \<psi>s))
        (max_pos_conj_depth_inner (Conj I \<psi>s))
+       (max_pos_conj_secondary_depth_inner (Conj I \<psi>s))
        (max_neg_conj_depth_inner (Conj I \<psi>s))
-       (neg_depth_inner (Conj I \<psi>s)) \<le> (E e1 e2 e3 e4 (e5-1) e6 e7 e8)\<close>
+       (neg_depth_inner (Conj I \<psi>s)) \<le> (E e1 e2 e3 e4 (e5-1) e6 e7 e8 e9)\<close>
     using is_some assms
     by (metis expr_pr_inner.simps option.discI option.inject)
   hence
@@ -689,8 +774,9 @@ proof-
     \<open>(st_conj_depth_inner (Conj I \<psi>s))\<le> e4\<close>
     \<open>(imm_conj_depth_inner (Conj I \<psi>s))\<le> (e5-1)\<close>
     \<open>(max_pos_conj_depth_inner (Conj I \<psi>s)) \<le> e6\<close>
-    \<open>(max_neg_conj_depth_inner (Conj I \<psi>s)) \<le> e7\<close>
-    \<open>(neg_depth_inner (Conj I \<psi>s))\<le> e8\<close>
+    \<open>(max_pos_conj_secondary_depth_inner (Conj I \<psi>s)) \<le> e7\<close>
+    \<open>(max_neg_conj_depth_inner (Conj I \<psi>s)) \<le> e8\<close>
+    \<open>(neg_depth_inner (Conj I \<psi>s))\<le> e9\<close>
     by auto
   hence E:
     \<open>Sup ((modal_depth_srbb_conjunct \<circ> \<psi>s) ` I) \<le> e1\<close>
@@ -699,20 +785,21 @@ proof-
     \<open>Sup ((st_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> e4\<close>
     \<open>Sup ((imm_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> (e5-1)\<close>
     \<open>Sup ((max_pos_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> e6\<close>
-    \<open>Sup ((max_neg_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> e7\<close>
-    \<open>Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I) \<le> e8\<close>
+    \<open>Sup ((max_pos_conj_secondary_depth_conjunct \<circ> \<psi>s) ` I) \<le> e7\<close>
+    \<open>Sup ((max_neg_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> e8\<close>
+    \<open>Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I) \<le> e9\<close>
     using conj_upds by force+
-  from \<open>Sup ((imm_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> (e5-1)\<close> have \<open>(1 + Sup ((imm_conj_depth_conjunct \<circ> \<psi>s) ` I)) \<le> e5\<close>
-    using assms(1) \<open>e5>0\<close> is_some e_def add.right_neutral add_diff_cancel_enat enat_add_left_cancel_le ileI1 le_iff_add plus_1_eSuc(1)
+  hence \<open>(1 + Sup ((imm_conj_depth_conjunct \<circ> \<psi>s) ` I)) \<le> e5\<close>
+    using assms(1) \<open>e5>0\<close> is_some e_def add.right_neutral add_diff_cancel_enat
+      enat_add_left_cancel_le ileI1 le_iff_add plus_1_eSuc(1)
     by metis
   thus \<open>expressiveness_price (ImmConj I \<psi>s) \<le> e\<close> using imm_conj_upds E
     by (metis e_def  energy.sel expressiveness_price.elims leD somewhere_larger_eq)
-
 qed
 
 lemma expr_conj:
   assumes
-    \<open>subtract_fn 0 0 1 0 0 0 0 0 e = Some e'\<close>
+    \<open>subtract_fn 0 0 1 0 0 0 0 0 0 e = Some e'\<close>
     \<open>I \<noteq> {}\<close>
     \<open>\<forall>q \<in> I. expr_pr_conjunct (\<psi>s q) \<le> e'\<close>
   shows \<open>expr_pr_inner (Conj I \<psi>s) \<le> e\<close>
@@ -724,12 +811,13 @@ proof-
     \<open>st_conj_depth_inner (Conj I \<psi>s) = Sup ((st_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>imm_conj_depth_inner (Conj I \<psi>s) = Sup ((imm_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>max_pos_conj_depth_inner (Conj I \<psi>s) = Sup ((max_pos_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
+    \<open>max_pos_conj_secondary_depth_inner (Conj I \<psi>s) = Sup ((max_pos_conj_secondary_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>max_neg_conj_depth_inner (Conj I \<psi>s) = Sup ((max_neg_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>neg_depth_inner (Conj I \<psi>s) = Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     using assms by force+
-  obtain e1 e2 e3 e4 e5 e6 e7 e8 where e_def: \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8\<close>
+  obtain e1 e2 e3 e4 e5 e6 e7 e8 e9 where e_def: \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8 e9\<close>
     using energy.exhaust_sel by metis
-  hence is_some: \<open>e - (E 0 0 1 0 0 0 0 0) = E e1 e2 (e3-1) e4 e5 e6 e7 e8\<close>
+  hence is_some: \<open>e - (E 0 0 1 0 0 0 0 0 0) = E e1 e2 (e3-1) e4 e5 e6 e7 e8 e9\<close>
     using minus_energy_def by simp
   hence \<open>e3>0\<close> using assms(1) e_def leq_components by auto
   hence
@@ -739,8 +827,9 @@ proof-
     \<open>\<forall>i \<in> I. st_conj_depth_conjunct (\<psi>s i) \<le> e4\<close>
     \<open>\<forall>i \<in> I. imm_conj_depth_conjunct (\<psi>s i) \<le> e5\<close>
     \<open>\<forall>i \<in> I. max_pos_conj_depth_conjunct (\<psi>s i) \<le> e6\<close>
-    \<open>\<forall>i \<in> I. max_neg_conj_depth_conjunct (\<psi>s i) \<le> e7\<close>
-    \<open>\<forall>i \<in> I. neg_depth_conjunct (\<psi>s i) \<le> e8\<close>
+    \<open>\<forall>i \<in> I. max_pos_conj_secondary_depth_conjunct (\<psi>s i) \<le> e7\<close>
+    \<open>\<forall>i \<in> I. max_neg_conj_depth_conjunct (\<psi>s i) \<le> e8\<close>
+    \<open>\<forall>i \<in> I. neg_depth_conjunct (\<psi>s i) \<le> e9\<close>
     using assms is_some energy.sel leq_components
     by (metis expr_pr_conjunct.elims option.distinct(1) option.inject)+
   hence sups:
@@ -750,8 +839,9 @@ proof-
     \<open>Sup ((st_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> e4\<close>
     \<open>Sup ((imm_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> e5\<close>
     \<open>Sup ((max_pos_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> e6\<close>
-    \<open>Sup ((max_neg_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> e7\<close>
-    \<open>Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I) \<le> e8\<close>
+    \<open>Sup ((max_pos_conj_secondary_depth_conjunct \<circ> \<psi>s) ` I) \<le> e7\<close>
+    \<open>Sup ((max_neg_conj_depth_conjunct \<circ> \<psi>s) ` I) \<le> e8\<close>
+    \<open>Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I) \<le> e9\<close>
     by (simp add: Sup_le_iff)+
   hence \<open>inst_conj_depth_inner (Conj I \<psi>s) \<le> e3\<close>
     using \<open>e3>0\<close> is_some e_def
@@ -765,27 +855,27 @@ qed
 
 lemma expr_br_conj:
   assumes
-    \<open>subtract_fn 0 1 1 0 0 0 0 0 e = Some e'\<close>
+    \<open>subtract_fn 0 1 1 0 0 0 0 0 0 e = Some e'\<close>
     \<open>min1_6 e' = Some e''\<close>
-    \<open>subtract_fn 1 0 0 0 0 0 0 0 e'' = Some e'''\<close>
+    \<open>subtract_fn 1 0 0 0 0 0 0 0 0 e'' = Some e'''\<close>
     \<open>expressiveness_price \<phi> \<le> e'''\<close>
     \<open>\<forall>q \<in> Q. expr_pr_conjunct (\<Phi> q) \<le> e'\<close>
     \<open>1 + modal_depth_srbb \<phi> \<le> pos_conjuncts e\<close>
   shows \<open>expr_pr_inner (BranchConj \<alpha> \<phi> Q \<Phi>) \<le> e\<close>
 proof-
-  obtain e1 e2 e3 e4 e5 e6 e7 e8 where e_def: \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8\<close>
-    by (smt (z3) energy.exhaust)
-  hence e'''_def: \<open>e''' = (E ((min e1 e6)-1) (e2-1) (e3-1) e4 e5 e6 e7 e8)\<close>
+  obtain e1 e2 e3 e4 e5 e6 e7 e8 e9 where e_def: \<open>e = E e1 e2 e3 e4 e5 e6 e7 e8 e9\<close>
+    using energy.exhaust by blast
+  hence e'''_def: \<open>e''' = (E ((min e1 e6)-1) (e2-1) (e3-1) e4 e5 e6 e7 e8 e9)\<close>
     using minus_energy_def
     by (smt (z3) assms energy.sel idiff_0_right min_1_6_simps option.distinct(1) option.sel)
-  hence min_vals: \<open>the (min1_6 (e - E 0 1 1 0 0 0 0 0)) - (E 1 0 0 0 0 0 0 0) = (E ((min e1 e6)-1) (e2-1) (e3-1) e4 e5 e6 e7 e8)\<close>
+  hence min_vals: \<open>the (min1_6 (e - E 0 1 1 0 0 0 0 0 0)) - (E 1 0 0 0 0 0 0 0 0) = (E ((min e1 e6)-1) (e2-1) (e3-1) e4 e5 e6 e7 e8 e9)\<close>
     using assms
     by (metis not_Some_eq option.sel)
   hence \<open>0 < e1\<close> \<open>0 < e2\<close> \<open>0 < e3\<close> \<open>0 < e6\<close>
     using assms energy.sel min_1_6_simps
     unfolding e_def minus_energy_def leq_components
     by (metis (no_types, lifting) gr_zeroI idiff_0_right min_enat_simps(3) not_one_le_zero option.distinct(1) option.sel, auto)
-  have e_comp: \<open>e - (E 0 1 1 0 0 0 0 0) = E e1 (e2-1) (e3-1) e4 e5 e6 e7 e8\<close> using e_def
+  have e_comp: \<open>e - (E 0 1 1 0 0 0 0 0 0) = E e1 (e2-1) (e3-1) e4 e5 e6 e7 e8 e9\<close> using e_def
     by simp
   have conj:
     \<open>E (modal_depth_srbb            \<phi>)
@@ -794,9 +884,10 @@ proof-
        (stable_conjunction_depth    \<phi>)
        (immediate_conjunction_depth \<phi>)
        (max_positive_conjunct_depth \<phi>)
+       (max_positive_conjunct_secondary_depth \<phi>)
        (max_negative_conjunct_depth \<phi>)
        (negation_depth              \<phi>)
-          \<le> ((E ((min e1 e6)-1) (e2-1) (e3-1) e4 e5 e6 e7 e8))\<close>
+          \<le> ((E ((min e1 e6)-1) (e2-1) (e3-1) e4 e5 e6 e7 e8 e9))\<close>
     using assms e'''_def by force
   hence conj_single:
     \<open>modal_depth_srbb \<phi>              \<le> ((min e1 e6)-1)\<close>
@@ -805,8 +896,9 @@ proof-
     \<open>(stable_conjunction_depth    \<phi>) \<le> e4\<close>
     \<open>(immediate_conjunction_depth \<phi>) \<le> e5\<close>
     \<open>(max_positive_conjunct_depth \<phi>) \<le> e6\<close>
-    \<open>(max_negative_conjunct_depth \<phi>) \<le> e7\<close>
-    \<open>(negation_depth              \<phi>) \<le> e8\<close>
+    \<open>(max_positive_conjunct_secondary_depth \<phi>) \<le> e7\<close>
+    \<open>(max_negative_conjunct_depth \<phi>) \<le> e8\<close>
+    \<open>(negation_depth              \<phi>) \<le> e9\<close>
     using leq_components by auto
   have \<open>0 < (min e1 e6)\<close> using \<open>0 < e1\<close> \<open>0 < e6\<close>
     using min_less_iff_conj by blast
@@ -827,9 +919,10 @@ proof-
       (st_conj_depth_conjunct  (\<Phi> q))
       (imm_conj_depth_conjunct  (\<Phi> q))
       (max_pos_conj_depth_conjunct  (\<Phi> q))
+      (max_pos_conj_secondary_depth_conjunct  (\<Phi> q))
       (max_neg_conj_depth_conjunct  (\<Phi> q))
       (neg_depth_conjunct  (\<Phi> q))
-    \<le> (E e1 (e2-1) (e3-1) e4 e5 e6 e7 e8)\<close>
+    \<le> (E e1 (e2-1) (e3-1) e4 e5 e6 e7 e8 e9)\<close>
     using assms e_def e_comp
     by (metis expr_pr_conjunct.simps option.distinct(1) option.sel)
   hence branch_single:
@@ -839,8 +932,9 @@ proof-
     \<open>\<forall>q\<in>Q. (st_conj_depth_conjunct  (\<Phi> q)) \<le> e4\<close>
     \<open>\<forall>q\<in>Q. (imm_conj_depth_conjunct  (\<Phi> q)) \<le> e5\<close>
     \<open>\<forall>q\<in>Q. (max_pos_conj_depth_conjunct  (\<Phi> q)) \<le> e6\<close>
-    \<open>\<forall>q\<in>Q. (max_neg_conj_depth_conjunct  (\<Phi> q)) \<le> e7\<close>
-    \<open>\<forall>q\<in>Q. (neg_depth_conjunct  (\<Phi> q)) \<le> e8\<close>
+    \<open>\<forall>q\<in>Q. (max_pos_conj_secondary_depth_conjunct  (\<Phi> q)) \<le> e7\<close>
+    \<open>\<forall>q\<in>Q. (max_neg_conj_depth_conjunct  (\<Phi> q)) \<le> e8\<close>
+    \<open>\<forall>q\<in>Q. (neg_depth_conjunct  (\<Phi> q)) \<le> e9\<close>
     by auto
   hence \<open>\<forall>q\<in>Q. (1 + branch_conj_depth_conjunct  (\<Phi> q)) \<le> e2\<close>
     by (metis \<open>0 < e2\<close> add.commute add_diff_assoc_enat add_diff_cancel_enat add_right_mono i1_ne_infinity ileI1 one_eSuc)
@@ -855,6 +949,7 @@ proof-
       (st_conj_depth_inner (BranchConj \<alpha> \<phi> Q \<Phi>))
       (imm_conj_depth_inner (BranchConj \<alpha> \<phi> Q \<Phi>))
       (max_pos_conj_depth_inner (BranchConj \<alpha> \<phi> Q \<Phi>))
+      (max_pos_conj_secondary_depth_inner (BranchConj \<alpha> \<phi> Q \<Phi>))
       (max_neg_conj_depth_inner (BranchConj \<alpha> \<phi> Q \<Phi>))
       (neg_depth_inner (BranchConj \<alpha> \<phi> Q \<Phi>))\<close> by simp
   hence expr:
@@ -865,6 +960,7 @@ proof-
       (Sup ({stable_conjunction_depth \<phi>} \<union> ((st_conj_depth_conjunct \<circ> \<Phi>) ` Q)))
       (Sup ({immediate_conjunction_depth \<phi>} \<union> ((imm_conj_depth_conjunct \<circ> \<Phi>) ` Q)))
       (Sup ({1 + modal_depth_srbb \<phi>, max_positive_conjunct_depth \<phi>} \<union> ((max_pos_conj_depth_conjunct \<circ> \<Phi>) ` Q)))
+      (Sup ({1 + modal_depth_srbb \<phi>, max_positive_conjunct_secondary_depth \<phi>} \<union> ((max_positive_conjunct_secondary_depth \<circ> \<Phi>) ` Q)))
       (Sup ({max_negative_conjunct_depth \<phi>} \<union> ((max_neg_conj_depth_conjunct \<circ> \<Phi>) ` Q)))
       (Sup ({negation_depth \<phi>} \<union> ((neg_depth_conjunct \<circ> \<Phi>) ` Q)))\<close> by auto
   from branch_single \<open>1 + modal_depth_srbb \<phi> \<le> e1\<close>
@@ -964,6 +1060,7 @@ lemma example_\<phi>_cp:
   and \<open>stable_conjunction_depth    \<phi> = 0\<close>
   and \<open>immediate_conjunction_depth \<phi> = 0\<close>
   and \<open>max_positive_conjunct_depth \<phi> = 1\<close>
+  and \<open>max_positive_conjunct_secondary_depth \<phi> = 1\<close>
   and \<open>max_negative_conjunct_depth \<phi> = 0\<close>
   and \<open>negation_depth              \<phi> = 0\<close>
   unfolding \<phi>

--- a/Expressiveness_Price.thy
+++ b/Expressiveness_Price.thy
@@ -1002,20 +1002,21 @@ qed
 
 lemma expressiveness_price_ImmConj_geq_parts:
   assumes \<open>i \<in> I\<close>
-  shows \<open>expressiveness_price (ImmConj I \<psi>s) - E 0 0 1 0 1 0 0 0 \<ge> expr_pr_conjunct (\<psi>s i)\<close>
+  shows \<open>expressiveness_price (ImmConj I \<psi>s) - E 0 0 1 0 1 0 0 0 0 \<ge> expr_pr_conjunct (\<psi>s i)\<close>
 proof-
   from assms have \<open>I \<noteq> {}\<close> by blast
   from expressiveness_price_ImmConj_non_empty_def[OF \<open>I \<noteq> {}\<close>]
-  have \<open>expressiveness_price (ImmConj I \<psi>s) \<ge> E 0 0 1 0 1 0 0 0\<close>
+  have \<open>expressiveness_price (ImmConj I \<psi>s) \<ge> E 0 0 1 0 1 0 0 0 0\<close>
     using energy_leq_cases by force
   hence
-  \<open>expressiveness_price (ImmConj I \<psi>s) - E 0 0 1 0 1 0 0 0 = E
+  \<open>expressiveness_price (ImmConj I \<psi>s) - E 0 0 1 0 1 0 0 0 0 = E
     (Sup ((modal_depth_srbb_conjunct \<circ> \<psi>s) ` I))
     (Sup ((branch_conj_depth_conjunct \<circ> \<psi>s) ` I))
     (Sup ((inst_conj_depth_conjunct \<circ> \<psi>s) ` I))
     (Sup ((st_conj_depth_conjunct \<circ> \<psi>s) ` I))
     (Sup ((imm_conj_depth_conjunct \<circ> \<psi>s) ` I))
     (Sup ((max_pos_conj_depth_conjunct \<circ> \<psi>s) ` I))
+    (Sup ((max_pos_conj_secondary_depth_conjunct \<circ> \<psi>s) ` I))
     (Sup ((max_neg_conj_depth_conjunct \<circ> \<psi>s) ` I))
     (Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I))\<close>
     unfolding expressiveness_price_ImmConj_non_empty_def[OF \<open>I \<noteq> {}\<close>]
@@ -1027,7 +1028,7 @@ qed
 
 lemma expressiveness_price_ImmConj_geq_parts':
   assumes \<open>i \<in> I\<close>
-  shows \<open>(expressiveness_price (ImmConj I \<psi>s) - E 0 0 0 0 1 0 0 0) - E 0 0 1 0 0 0 0 0 \<ge> expr_pr_conjunct (\<psi>s i)\<close>
+  shows \<open>(expressiveness_price (ImmConj I \<psi>s) - E 0 0 0 0 1 0 0 0 0) - E 0 0 1 0 0 0 0 0 0 \<ge> expr_pr_conjunct (\<psi>s i)\<close>
   using expressiveness_price_ImmConj_geq_parts[OF assms]
     less_eq_energy_def minus_energy_def
   by (smt (z3) energy.sel idiff_0_right)
@@ -1062,7 +1063,7 @@ lemma example_\<phi>_cp:
   and \<open>stable_conjunction_depth    \<phi> = 0\<close>
   and \<open>immediate_conjunction_depth \<phi> = 0\<close>
   and \<open>max_positive_conjunct_depth \<phi> = 1\<close>
-  and \<open>max_positive_conjunct_secondary_depth \<phi> = 1\<close>
+  and \<open>max_positive_conjunct_secondary_depth \<phi> = 0\<close>
   and \<open>max_negative_conjunct_depth \<phi> = 0\<close>
   and \<open>negation_depth              \<phi> = 0\<close>
   unfolding \<phi>
@@ -1076,7 +1077,7 @@ lemma \<open>expressiveness_price (Internal
                       then (Pos (Obs a TT))
                       else if i = right
                            then (Pos (Obs b TT))
-                           else undefined)))))) = E 2 0 1 0 0 1 0 0\<close>
+                           else undefined)))))) = E 2 0 1 0 0 1 0 0 0\<close>
   by simp
 
 end (* Inhabited_LTS *)
@@ -1084,20 +1085,20 @@ end (* Inhabited_LTS *)
 context LTS_Tau
 begin
 
-lemma \<open>expressiveness_price TT = E 0 0 0 0 0 0 0 0\<close>
+lemma \<open>expressiveness_price TT = E 0 0 0 0 0 0 0 0 0\<close>
   by simp
 
-lemma \<open>expressiveness_price (ImmConj {} \<psi>s) = E 0 0 0 0 0 0 0 0\<close>
+lemma \<open>expressiveness_price (ImmConj {} \<psi>s) = E 0 0 0 0 0 0 0 0 0\<close>
   by (simp add: Sup_enat_def)
 
-lemma \<open>expressiveness_price (Internal (Conj {} \<psi>s)) = E 0 0 0 0 0 0 0 0\<close>
+lemma \<open>expressiveness_price (Internal (Conj {} \<psi>s)) = E 0 0 0 0 0 0 0 0 0\<close>
   by (simp add: Sup_enat_def)
 
-lemma \<open>expressiveness_price (Internal (BranchConj \<alpha> TT {} \<psi>s)) = E 1 1 1 0 0 1 0 0\<close>
+lemma \<open>expressiveness_price (Internal (BranchConj \<alpha> TT {} \<psi>s)) = E 1 1 1 0 0 1 0 0 0\<close>
   by (simp add: Sup_enat_def)
 
 lemma expr_obs_phi:
-  shows \<open>subtract_fn 1 0 0 0 0 0 0 0 (expr_pr_inner (Obs \<alpha> \<phi>)) = Some (expressiveness_price \<phi>)\<close>
+  shows \<open>subtract_fn 1 0 0 0 0 0 0 0 0 (expr_pr_inner (Obs \<alpha> \<phi>)) = Some (expressiveness_price \<phi>)\<close>
   by simp
 
 subsection \<open>Characterizing Equivalence by Energy Coordinates\<close>
@@ -1115,7 +1116,7 @@ subsection \<open>Relational Effects of Prices\<close>
 
 lemma distinction_combination_eta:
   fixes p q
-  defines \<open>Q\<alpha> \<equiv> {q'. q \<Zsurj> q' \<and>  (\<nexists>\<phi>. \<phi> \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0) \<and> distinguishes \<phi> p q')}\<close>
+  defines \<open>Q\<alpha> \<equiv> {q'. q \<Zsurj> q' \<and>  (\<nexists>\<phi>. \<phi> \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 0 0) \<and> distinguishes \<phi> p q')}\<close>
   assumes
     \<open>p \<mapsto>a \<alpha> p'\<close>
     \<open>\<forall>q'\<in> Q\<alpha>.
@@ -1144,15 +1145,15 @@ qed
 lemma distinction_conjunctification_two_way_price:
   assumes
     \<open>\<forall>q\<in>I. distinguishes (\<Phi> q) p q \<or> distinguishes (\<Phi> q) q p\<close>
-    \<open>\<forall>q\<in>I. \<Phi> q \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+    \<open>\<forall>q\<in>I. \<Phi> q \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> e7 \<infinity> \<infinity>)\<close>
   shows
     \<open>\<forall>q\<in>I.
       (if distinguishes (\<Phi> q) p q then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi> p q
-      \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+      \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> e7 \<infinity> \<infinity>)\<close>
 proof
   fix q
   assume \<open>q \<in> I\<close>
-  show \<open>(if distinguishes (\<Phi> q) p q then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi> p q \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>)\<close>
+  show \<open>(if distinguishes (\<Phi> q) p q then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi> p q \<in> \<O>_conjunct (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> e7 \<infinity> \<infinity>)\<close>
   proof (cases \<open>\<Phi> q\<close>)
     case TT
     then show ?thesis
@@ -1177,7 +1178,7 @@ qed
 lemma distinction_combination_eta_two_way:
   fixes p q p' \<Phi>
   defines
-    \<open>Q\<alpha> \<equiv> {q'. q \<Zsurj> q' \<and>  (\<nexists>\<phi>. \<phi> \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> \<infinity> \<infinity>) \<and> (distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p))}\<close> and
+    \<open>Q\<alpha> \<equiv> {q'. q \<Zsurj> q' \<and>  (\<nexists>\<phi>. \<phi> \<in> \<O> (E \<infinity> \<infinity> \<infinity> 0 0 \<infinity> 0 \<infinity> \<infinity>) \<and> (distinguishes \<phi> p q' \<or> distinguishes \<phi> q' p))}\<close> and
     \<open>\<Psi>\<alpha> \<equiv> \<lambda>q'''. (if distinguishes (\<Phi> q''') p' q''' then conjunctify_distinctions else conjunctify_distinctions_dual) \<Phi> p' q'''\<close>
   assumes
     \<open>p \<mapsto>a \<alpha> p'\<close>
@@ -1258,29 +1259,29 @@ proof
 qed
 
 lemma modal_stability_respecting:
-  \<open>stability_respecting (preordered (\<O> (E e1 e2 e3 \<infinity> e5 \<infinity> e7 e8)))\<close>
+  \<open>stability_respecting (preordered (\<O> (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)))\<close>
   unfolding stability_respecting_def
 proof safe
   fix p q
   assume p_stability:
-    \<open>preordered (\<O> (E e1 e2 e3 \<infinity> e5 \<infinity> e7 e8)) p q\<close>
+    \<open>preordered (\<O> (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)) p q\<close>
     \<open>stable_state p\<close>
-  have \<open>\<not>(\<forall>q'. q \<Zsurj> q' \<longrightarrow> \<not> preordered (\<O> (E e1 e2 e3 \<infinity> e5 \<infinity> e7 e8)) p q' \<or> \<not> stable_state q')\<close>
+  have \<open>\<not>(\<forall>q'. q \<Zsurj> q' \<longrightarrow> \<not> preordered (\<O> (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)) p q' \<or> \<not> stable_state q')\<close>
   proof safe
-    assume \<open>\<forall>q'. q \<Zsurj> q' \<longrightarrow> \<not> preordered (\<O> (E e1 e2 e3 \<infinity> e5 \<infinity> e7 e8)) p q' \<or> \<not> stable_state q'\<close>
-    hence  \<open>\<forall>q'. q \<Zsurj> q' \<longrightarrow> stable_state q' \<longrightarrow> (\<exists>\<phi> \<in> \<O> (E e1 e2 e3 \<infinity> e5 \<infinity> e7 e8). distinguishes \<phi> p q')\<close> by auto
+    assume \<open>\<forall>q'. q \<Zsurj> q' \<longrightarrow> \<not> preordered (\<O> (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)) p q' \<or> \<not> stable_state q'\<close>
+    hence  \<open>\<forall>q'. q \<Zsurj> q' \<longrightarrow> stable_state q' \<longrightarrow> (\<exists>\<phi> \<in> \<O> (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9). distinguishes \<phi> p q')\<close> by auto
     then obtain \<Phi> where \<Phi>_def:
       \<open>\<forall>q'\<in>(silent_reachable_set {q}). stable_state q'
-      \<longrightarrow> distinguishes (\<Phi> q') p q' \<and> \<Phi> q' \<in> \<O> (E e1 e2 e3 \<infinity> e5 \<infinity> e7 e8)\<close>
+      \<longrightarrow> distinguishes (\<Phi> q') p q' \<and> \<Phi> q' \<in> \<O> (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)\<close>
       using singleton_iff sreachable_set_is_sreachable by metis
     hence distinctions:
       \<open>\<forall>q'\<in>(silent_reachable_set {q} \<inter> {q'. stable_state q'}). distinguishes (\<Phi> q') p q'\<close>
-      \<open>\<forall>q'\<in>(silent_reachable_set {q} \<inter> {q'. stable_state q'}). \<Phi> q' \<in> \<O> (E e1 e2 e3 \<infinity> e5 \<infinity> e7 e8)\<close> by blast+
+      \<open>\<forall>q'\<in>(silent_reachable_set {q} \<inter> {q'. stable_state q'}). \<Phi> q' \<in> \<O> (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)\<close> by blast+
     from distinction_conjunctification_price[OF this] have
-      \<open>\<forall>q'\<in>(silent_reachable_set {q} \<inter> {q'. stable_state q'}). conjunctify_distinctions \<Phi> p q' \<in> \<O>_conjunct (E e1 e2 e3 \<infinity> e5 \<infinity> e7 e8)\<close>
+      \<open>\<forall>q'\<in>(silent_reachable_set {q} \<inter> {q'. stable_state q'}). conjunctify_distinctions \<Phi> p q' \<in> \<O>_conjunct (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)\<close>
       by fastforce
     hence conj_price: \<open>StableConj (silent_reachable_set {q} \<inter> {q'. stable_state q'}) (conjunctify_distinctions \<Phi> p)
-        \<in> \<O>_inner (E e1 e2 e3 \<infinity> e5 \<infinity> e7 e8)\<close>
+        \<in> \<O>_inner (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)\<close>
       unfolding \<O>_inner_def \<O>_conjunct_def using SUP_le_iff by fastforce
     from \<Phi>_def have
       \<open>\<forall>q'\<in>(silent_reachable_set {q}). stable_state q' \<longrightarrow>
@@ -1299,12 +1300,12 @@ proof safe
       using silent_reachable.refl by auto
     moreover have
       \<open>Internal (StableConj (silent_reachable_set {q} \<inter> {q'. stable_state q'}) (conjunctify_distinctions \<Phi> p))
-        \<in> \<O> (E e1 e2 e3 \<infinity> e5 \<infinity> e7 e8)\<close>
+        \<in> \<O> (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)\<close>
       using conj_price unfolding \<O>_def \<O>_inner_def by simp
     ultimately show False
       using p_stability(1) preordered_no_distinction by blast
   qed
-  thus \<open>\<exists>q'. q \<Zsurj> q' \<and> preordered (\<O> (E e1 e2 e3 \<infinity> e5 \<infinity> e7 e8)) p q' \<and> stable_state q'\<close>
+  thus \<open>\<exists>q'. q \<Zsurj> q' \<and> preordered (\<O> (E e1 e2 e3 \<infinity> e5 \<infinity> \<infinity> e8 e9)) p q' \<and> stable_state q'\<close>
     by blast
 qed
 

--- a/Expressiveness_Price.thy
+++ b/Expressiveness_Price.thy
@@ -659,7 +659,7 @@ lemma expr_st_conj:
     \<open>subtract_fn  0 0 0 1 0 0 0 0 0 e = Some e'\<close>
     \<open>I \<noteq> {}\<close>
     \<open>\<forall>q \<in> I. expr_pr_conjunct (\<psi>s q) \<le> e'\<close>
-    \<open>pos_conjuncts_sec e' \<le> modal_depth e'\<close>
+    \<open>\<forall>q \<in> I - revival_conjunct_index I \<psi>s. is_pos (\<psi>s q) \<longrightarrow> modal_depth_srbb_conjunct (\<psi>s q) \<le> pos_conjuncts_sec e'\<close>
   shows
     \<open>expr_pr_inner (StableConj I \<psi>s) \<le> e\<close>
 proof -
@@ -671,7 +671,7 @@ proof -
     \<open>imm_conj_depth_inner (StableConj I \<psi>s) = Sup ((imm_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>max_pos_conj_depth_inner (StableConj I \<psi>s) = Sup ((max_pos_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>max_pos_conj_secondary_depth_inner (StableConj I \<psi>s) = 
-      Sup (((\<lambda>\<psi>. case \<psi> of (Pos \<chi>) \<Rightarrow> modal_depth_srbb_inner \<chi> | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct \<psi>) \<circ> \<psi>s)
+      Sup (((\<lambda>\<psi>. case \<psi> of (Pos \<chi>) \<Rightarrow> modal_depth_srbb_inner \<chi> | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct \<psi>) \<circ> \<psi>s)   
         ` (I - (revival_conjunct_index I \<psi>s)))\<close>
     \<open>max_neg_conj_depth_inner (StableConj I \<psi>s) = Sup ((max_neg_conj_depth_conjunct \<circ> \<psi>s) ` I)\<close>
     \<open>neg_depth_inner (StableConj I \<psi>s) = Sup ((neg_depth_conjunct \<circ> \<psi>s) ` I)\<close>
@@ -681,8 +681,7 @@ proof -
   hence is_some: \<open>subtract_fn  0 0 0 1 0 0 0 0 0 e = Some (E e1 e2 e3 (e4-1) e5 e6 e7 e8 e9)\<close>
     using assms minus_energy_def
     by (smt (verit, del_insts) energy_minus idiff_0_right option.distinct(1))
-  hence min_e1_e7: \<open>min e1 e7 = e7\<close> using is_some assms by auto
-  from is_some have
+  from is_some have e_leqs:
     \<open>\<forall>i \<in> I. modal_depth_srbb_conjunct (\<psi>s i) \<le> e1\<close>
     \<open>\<forall>i \<in> I. branch_conj_depth_conjunct (\<psi>s i) \<le> e2\<close>
     \<open>\<forall>i \<in> I. inst_conj_depth_conjunct (\<psi>s i) \<le> e3\<close>
@@ -690,6 +689,7 @@ proof -
     \<open>\<forall>i \<in> I. imm_conj_depth_conjunct (\<psi>s i) \<le> e5\<close>
     \<open>\<forall>i \<in> I. max_pos_conj_depth_conjunct (\<psi>s i) \<le> e6\<close>
     \<open>\<forall>i \<in> I. max_pos_conj_secondary_depth_conjunct (\<psi>s i) \<le> e7\<close>
+    \<open>\<forall>q \<in> I - revival_conjunct_index I \<psi>s. is_pos (\<psi>s q) \<longrightarrow> modal_depth_srbb_conjunct (\<psi>s q) \<le> e7\<close>
     \<open>\<forall>i \<in> I. max_neg_conj_depth_conjunct (\<psi>s i) \<le> e8\<close>
     \<open>\<forall>i \<in> I. neg_depth_conjunct (\<psi>s i) \<le> e9\<close>
     using assms unfolding leq_components
@@ -710,8 +710,8 @@ proof -
     by (metis add_diff_cancel_enat add_left_mono enat.simps(3) enat_defs(2) energy.sel(4) le_iff_add option.distinct(1))
   moreover have \<open>\<forall>i \<in> I. i \<notin> revival_conjunct_index I \<psi>s \<longrightarrow>
     (case \<psi>s i of Pos \<chi> \<Rightarrow> modal_depth_srbb_inner \<chi> | _ \<Rightarrow> max_pos_conj_secondary_depth_conjunct (\<psi>s i)) \<le> e7\<close>
-    using sups st_conj_upds unfolding e_def revival_conjunct_index_def max_def
-    sorry
+    using e_leqs(8,10) modal_depth_srbb_rewrite
+    by (metis Diff_iff e_leqs(7) hml_srbb_conjunct.case_eq_if hml_srbb_conjunct.collapse(1))
   ultimately show ?thesis
     using st_conj_upds sups \<open>subtract_fn  0 0 0 1 0 0 0 0 0 e = Some e'\<close>
     unfolding e_def
@@ -960,7 +960,7 @@ proof-
       (Sup ({stable_conjunction_depth \<phi>} \<union> ((st_conj_depth_conjunct \<circ> \<Phi>) ` Q)))
       (Sup ({immediate_conjunction_depth \<phi>} \<union> ((imm_conj_depth_conjunct \<circ> \<Phi>) ` Q)))
       (Sup ({1 + modal_depth_srbb \<phi>, max_positive_conjunct_depth \<phi>} \<union> ((max_pos_conj_depth_conjunct \<circ> \<Phi>) ` Q)))
-      (Sup ({1 + modal_depth_srbb \<phi>, max_positive_conjunct_secondary_depth \<phi>} \<union> ((max_positive_conjunct_secondary_depth \<circ> \<Phi>) ` Q)))
+      (Sup ({max_positive_conjunct_secondary_depth \<phi>} \<union> ((max_pos_conj_secondary_depth_conjunct \<circ> \<Phi>) ` Q)))
       (Sup ({max_negative_conjunct_depth \<phi>} \<union> ((max_neg_conj_depth_conjunct \<circ> \<Phi>) ` Q)))
       (Sup ({negation_depth \<phi>} \<union> ((neg_depth_conjunct \<circ> \<Phi>) ` Q)))\<close> by auto
   from branch_single \<open>1 + modal_depth_srbb \<phi> \<le> e1\<close>
@@ -983,15 +983,17 @@ proof-
     \<open>\<forall>x \<in> ({stable_conjunction_depth \<phi>} \<union> ((st_conj_depth_conjunct \<circ> \<Phi>) ` Q)). x \<le> e4\<close>
     \<open>\<forall>x \<in> ({immediate_conjunction_depth \<phi>} \<union> ((imm_conj_depth_conjunct \<circ> \<Phi>) ` Q)). x \<le> e5\<close>
     \<open>\<forall>x \<in> ({1 + modal_depth_srbb \<phi>, max_positive_conjunct_depth \<phi>} \<union> ((max_pos_conj_depth_conjunct \<circ> \<Phi>) ` Q)). x \<le> e6\<close>
-    \<open>\<forall>x \<in> ({max_negative_conjunct_depth \<phi>} \<union> ((max_neg_conj_depth_conjunct \<circ> \<Phi>) ` Q)). x \<le> e7\<close>
-    \<open>\<forall>x \<in> ({negation_depth \<phi>} \<union> ((neg_depth_conjunct \<circ> \<Phi>) ` Q)). x \<le> e8\<close>
+    \<open>\<forall>x \<in> ({max_positive_conjunct_secondary_depth \<phi>} \<union> ((max_pos_conj_secondary_depth_conjunct \<circ> \<Phi>) ` Q)). x \<le> e7\<close>
+    \<open>\<forall>x \<in> ({max_negative_conjunct_depth \<phi>} \<union> ((max_neg_conj_depth_conjunct \<circ> \<Phi>) ` Q)). x \<le> e8\<close>
+    \<open>\<forall>x \<in> ({negation_depth \<phi>} \<union> ((neg_depth_conjunct \<circ> \<Phi>) ` Q)). x \<le> e9\<close>
       using conj_single branch_single \<open>1 + modal_depth_srbb \<phi> \<le> e6\<close> by auto
   hence
     \<open>(Sup ({stable_conjunction_depth \<phi>} \<union> ((st_conj_depth_conjunct \<circ> \<Phi>) ` Q))) \<le> e4\<close>
     \<open>(Sup ({immediate_conjunction_depth \<phi>} \<union> ((imm_conj_depth_conjunct \<circ> \<Phi>) ` Q))) \<le> e5\<close>
     \<open>(Sup ({1 + modal_depth_srbb \<phi>, max_positive_conjunct_depth \<phi>} \<union> ((max_pos_conj_depth_conjunct \<circ> \<Phi>) ` Q))) \<le> e6\<close>
-    \<open>(Sup ({max_negative_conjunct_depth \<phi>} \<union> ((max_neg_conj_depth_conjunct \<circ> \<Phi>) ` Q))) \<le> e7\<close>
-    \<open>(Sup ({negation_depth \<phi>} \<union> ((neg_depth_conjunct \<circ> \<Phi>) ` Q))) \<le> e8\<close>
+    \<open>(Sup ({max_positive_conjunct_secondary_depth \<phi>} \<union> ((max_pos_conj_secondary_depth_conjunct \<circ> \<Phi>) ` Q))) \<le> e7\<close>
+    \<open>(Sup ({max_negative_conjunct_depth \<phi>} \<union> ((max_neg_conj_depth_conjunct \<circ> \<Phi>) ` Q))) \<le> e8\<close>
+    \<open>(Sup ({negation_depth \<phi>} \<union> ((neg_depth_conjunct \<circ> \<Phi>) ` Q))) \<le> e9\<close>
     using Sup_least
     by metis+
   thus \<open>expr_pr_inner (BranchConj \<alpha> \<phi> Q \<Phi>) \<le> e\<close>

--- a/HML_SRBB.thy
+++ b/HML_SRBB.thy
@@ -59,7 +59,7 @@ and
                \<open>'i set\<close> \<open>'i \<Rightarrow> ('act, 'i) hml_srbb_conjunct\<close>
 and
   ('act, 'i) hml_srbb_conjunct =
-    Pos \<open>('act, 'i) hml_srbb_inner\<close> |
+    is_pos: Pos \<open>('act, 'i) hml_srbb_inner\<close> |
     Neg \<open>('act, 'i) hml_srbb_inner\<close>
 
 

--- a/HML_SRBB.thy
+++ b/HML_SRBB.thy
@@ -54,8 +54,8 @@ and
   ('act, 'i) hml_srbb_inner =
     Obs 'act \<open>('act, 'i) hml_srbb\<close> |
     Conj \<open>'i set\<close> \<open>'i \<Rightarrow> ('act, 'i) hml_srbb_conjunct\<close> |
-    StableConj \<open>'i set\<close> \<open>'i \<Rightarrow> ('act, 'i) hml_srbb_conjunct\<close> |
-    BranchConj 'act \<open>('act, 'i) hml_srbb\<close>
+    StableConj \<open>'i option set\<close> \<open>'i option \<Rightarrow> ('act, 'i) hml_srbb_conjunct\<close> |
+    BranchConj \<open>'act\<close> \<open>('act, 'i) hml_srbb\<close>
                \<open>'i set\<close> \<open>'i \<Rightarrow> ('act, 'i) hml_srbb_conjunct\<close>
 and
   ('act, 'i) hml_srbb_conjunct =
@@ -440,6 +440,43 @@ proof
       using assms q_I by auto
     then show ?thesis
       by (metis (mono_tags, lifting) ImmConj hml_srbb.simps(11) someI)
+  qed
+qed
+
+
+definition conjunctify_distinctions_opt ::
+  \<open>('s \<Rightarrow> ('a, 's) hml_srbb) \<Rightarrow> 's \<Rightarrow> ('s option \<Rightarrow> ('a, 's) hml_srbb_conjunct)\<close> where
+  \<open>conjunctify_distinctions_opt \<Phi> p \<equiv> \<lambda>q.
+    case (\<Phi> (the q)) of
+      TT \<Rightarrow> undefined
+    | Internal \<chi> \<Rightarrow> Pos \<chi>
+    | ImmConj I \<Psi> \<Rightarrow> \<Psi> (SOME i. i\<in>I \<and> hml_srbb_conj.distinguishes (\<Psi> i) p (the q))\<close>
+
+lemma distinction_conjunctification_opt:
+  assumes
+    \<open>\<forall>q\<in>I. distinguishes (\<Phi> q) p q\<close>
+  shows
+    \<open>\<forall>q\<in>I. hml_srbb_conj.distinguishes ((conjunctify_distinctions_opt \<Phi> p) (Some q)) p q\<close>
+  unfolding conjunctify_distinctions_opt_def
+proof
+  fix q
+  assume q_I: \<open>q\<in>I\<close>
+  show \<open>hml_srbb_conj.distinguishes
+          (case \<Phi> (the (Some q)) of hml_srbb.Internal x \<Rightarrow> hml_srbb_conjunct.Pos x
+           | ImmConj I \<Psi> \<Rightarrow> \<Psi> (SOME i. i \<in> I \<and> hml_srbb_conj.distinguishes (\<Psi> i) p (the (Some q))))
+          p q\<close>
+  proof (cases \<open>\<Phi> q\<close>)
+    case TT
+    then show ?thesis using assms q_I by fastforce
+  next
+    case (Internal \<chi>)
+    then show ?thesis using assms q_I by auto
+  next
+    case (ImmConj J \<Psi>)
+    then have \<open>\<exists>i \<in> J. hml_srbb_conj.distinguishes (\<Psi> i) p q\<close>
+      using assms q_I by auto
+    then show ?thesis
+      by (metis (mono_tags, lifting) ImmConj hml_srbb.simps(11) someI option.sel)
   qed
 qed
 

--- a/LTS.thy
+++ b/LTS.thy
@@ -359,6 +359,12 @@ lemma stable_state_stable:
   shows \<open>p = p'\<close>
   using assms(2,1) by (cases, blast+)
 
+lemma stable_state_stabilized:
+  assumes \<open>stable_state p\<close>
+  shows \<open>{p} \<Zsurj>S {p}\<close>
+  using assms
+  by (metis LTS_Tau.refl singletonD stable_state_stable)
+
 definition stability_respecting :: \<open>('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> bool\<close> where
   \<open>stability_respecting R \<equiv> \<forall> p q. R p q \<and> stable_state p \<longrightarrow>
     (\<exists>q'. q \<Zsurj> q' \<and> R p q' \<and> stable_state q')\<close>

--- a/Spectroscopy_Game.thy
+++ b/Spectroscopy_Game.thy
@@ -227,28 +227,41 @@ next
       assume upd: \<open>(if p = p' \<and> q' \<in> Q then Some (\<lambda>e. Option.bind (if \<not> E 0 0 0 1 0 0 0 0 0 \<le> e then None else Some (e - E 0 0 0 1 0 0 0 0 0)) min6_7) else None) = Some up\<close>
       hence \<open>up e = Some eu\<close> \<open>up e' = Some eu'\<close> using monotonicity_assms(2,3)
         by (auto simp add: Attacker_Stable_Clause Defender_Stable_Conj)
-      then show ?thesis using monotonicity_assms(2,3,4) upd min_6_7_subtr_mono unfolding mono_def
-        apply (auto simp add: min_6_7_subtr_simp) 
-        apply (metis (no_types, lifting) energy.sel min_6_7_subtr_simp option.discI option.sel)
-        apply (metis (no_types, lifting) energy.sel min_6_7_subtr_simp option.discI option.sel)
-              apply (metis (no_types, lifting) energy.sel min_6_7_subtr_simp option.discI option.sel)
-        apply (metis (no_types, lifting) enat_diff_mono energy.sel(4) min_6_7_subtr_simp option.discI option.sel)
-        apply (metis (no_types, lifting) energy.collapse energy.inject min_6_7_subtr_simp option.distinct(1) option.sel)
-        apply (metis (no_types, lifting) energy.sel(6) min_6_7_subtr_simp option.discI option.sel)
-        apply (smt (verit) bind_eq_None_conv energy.sel(4) leq_components option.case_eq_if option.discI option.sel)
-        apply (metis (no_types, lifting) energy.sel(8) min_6_7_subtr_simp option.discI option.sel)
-        by (metis (no_types, lifting) energy.sel(9) min_6_7_subtr_simp option.discI option.sel)
+      then show ?thesis
+        using monotonicity_assms(2,3,4) upd min_6_7_subtr_mono
+        apply (simp add: min_6_7_subtr_simp mono_def min_def)
+        by (smt (verit) bind_eq_None_conv energy.sel(4) leq_components option.case_eq_if option.discI option.sel)
     next
       case (Attacker_Delayed p' Q')
       then show ?thesis using monotonicity_assms(2,3,4) sorry
     next
       case (Defender_Conj p' Q')
-      then show ?thesis using monotonicity_assms(2,3,4) apply (smt (verit, best) mono_subtract option.sel option.simps(3))
+      then show ?thesis using monotonicity_assms(2,3,4) sorry
     qed
-
-      apply (cases g', simp_all del: leq_components)
-      
-      apply (smt (verit, ccfv_SIG) mono_subtract option.discI option.sel)
+  next
+    case (Attacker_Stable_Clause p q)
+    \<comment> \<open>Analogous to \<open>Attacker_Stable\<close> case\<close>
+    hence \<open>\<exists>p' Q'. g'= (Attacker_Delayed p' Q')\<close>
+      using monotonicity_assms(1,2) 
+      by (induct, auto)
+    hence \<open>spectroscopy_moves g g' =
+      Some min1_7 \<or> spectroscopy_moves g g' = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8)\<close>
+      using monotonicity_assms(1,2) Attacker_Stable_Clause
+      by (smt (verit, ccfv_threshold) spectroscopy_moves.simps(8))
+    thus ?thesis
+    proof safe
+      assume \<open>spectroscopy_moves g g' = Some min1_7\<close>
+      thus ?thesis
+        using monotonicity_assms min.mono
+        unfolding leq_components
+        by (metis min_1_7_simps option.sel)
+    next
+      assume \<open>spectroscopy_moves g g' = Some (\<lambda>e. Option.bind (if \<not> E 0 0 0 0 0 0 0 0 1 \<le> e then None else Some (e - E 0 0 0 0 0 0 0 0 1)) min1_8)\<close>
+      thus ?thesis
+        unfolding min_1_8_subtr_simp
+        using monotonicity_assms
+        by (smt (z3) enat_diff_mono energy.sel leq_components min.mono option.distinct(1) option.sel)
+    qed
   qed
 next
   fix g g' e e'
@@ -270,21 +283,40 @@ next
         (smt (verit, best) option.distinct(1) option.inject order.trans)+
   next
     case (Attacker_Clause p q)
-    hence \<open>\<exists>p' Q'. g'= (Attacker_Delayed p' Q')\<close>
+    then obtain p' Q' where \<open>g'=(Attacker_Delayed p' Q')\<close>
       using defender_win_min_assms(2)
-      by (metis spectroscopy_defender.cases spectroscopy_moves.simps(21,52,58,62,67,72))
-    hence \<open>spectroscopy_moves g g' = Some min1_6 \<or> spectroscopy_moves g g' = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 1) e) min1_7)\<close>
-      using defender_win_min_assms(2) Attacker_Clause
-      by (smt (verit, ccfv_threshold) spectroscopy_moves.simps(7))
+      by (cases g', auto)
+    hence \<open>spectroscopy_moves g g' = Some min1_6 \<or> spectroscopy_moves g g' = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8)\<close>
+      using defender_win_min_assms(2) Attacker_Clause pos_neg_clause
+      by (smt (verit))
     thus ?thesis
     proof safe
       assume \<open>spectroscopy_moves g g' = Some min1_6\<close>
       thus \<open>the (spectroscopy_moves g g') e = None\<close>
-        using defender_win_min_assms min_1_6_some by fastforce
+        using defender_win_min_assms min_some by fastforce
     next
-      assume \<open>spectroscopy_moves g g' = Some (\<lambda>e. Option.bind (if \<not> E 0 0 0 0 0 0 0 1 \<le> e then None else Some (e - E 0 0 0 0 0 0 0 1)) min1_7)\<close>
+      assume \<open>spectroscopy_moves g g' = Some (\<lambda>e. Option.bind (if \<not> E 0 0 0 0 0 0 0 0 1 \<le> e then None else Some (e - E 0 0 0 0 0 0 0 0 1)) min1_8)\<close>
       thus \<open>the (spectroscopy_moves g g') e = None\<close>
-        using defender_win_min_assms(1,3) bind.bind_lunit dual_order.trans min_1_7_some
+        using defender_win_min_assms(1,3) bind.bind_lunit dual_order.trans min_some
+        by (smt (verit, best) option.sel)
+    qed
+  next 
+    case (Attacker_Stable_Clause p q)
+    then obtain p' Q' where \<open>g'= (Attacker_Delayed p' Q')\<close>
+      using defender_win_min_assms(2)
+      by (cases g', auto)
+    hence \<open>spectroscopy_moves g g' = Some min1_7 \<or> spectroscopy_moves g g' = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8)\<close>
+      using defender_win_min_assms(2) Attacker_Stable_Clause pos_neg_stable_clause
+      by meson
+    thus ?thesis
+    proof safe
+      assume \<open>spectroscopy_moves g g' = Some min1_7\<close>
+      thus \<open>the (spectroscopy_moves g g') e = None\<close>
+        using defender_win_min_assms min_some by fastforce
+    next
+      assume \<open>spectroscopy_moves g g' = Some (\<lambda>e. Option.bind (if \<not> E 0 0 0 0 0 0 0 0 1 \<le> e then None else Some (e - E 0 0 0 0 0 0 0 0 1)) min1_8)\<close>
+      thus \<open>the (spectroscopy_moves g g') e = None\<close>
+        using defender_win_min_assms(1,3) bind.bind_lunit dual_order.trans min_some
         by (smt (verit, best) option.sel)
     qed
   next
@@ -292,9 +324,10 @@ next
     hence \<open>(\<exists>p' Q'. g'=(Attacker_Delayed p' Q')) \<or>
       (\<exists>p' Q'. g'=(Attacker_Immediate p' Q')) \<or>
       (\<exists>p' Q'. g'=(Defender_Conj p' Q')) \<or>
-      (\<exists>p' Q'. g'=(Defender_Stable_Conj p' Q')) \<or>
+      (\<exists>p' Q' Qr. g'=(Defender_Stable_Conj p' Q' Qr)) \<or>
       (\<exists>p' p'' Q' \<alpha> Q\<alpha> . g'= (Defender_Branch p' \<alpha> p'' Q' Q\<alpha>))\<close>
-      by (metis defender_win_min_assms(2) spectroscopy_defender.cases spectroscopy_moves.simps(27,59))
+      using defender_win_min_assms(2)
+      by (induct, auto)
     thus ?thesis
     proof (safe)
       fix p' Q'
@@ -306,10 +339,10 @@ next
     next
       fix p' Q'
       assume \<open>g' = Attacker_Immediate p' Q'\<close>
-      moreover hence \<open>spectroscopy_moves g g' = (subtract 1 0 0 0 0 0 0 0)\<close>
+      moreover hence \<open>spectroscopy_moves g g' = (subtract 1 0 0 0 0 0 0 0 0)\<close>
         using Attacker_Delayed defender_win_min_assms(2,3) local.observation
         by (clarify, presburger)
-      moreover hence \<open>\<not>E 1 0 0 0 0 0 0 0 \<le> e'\<close>
+      moreover hence \<open>\<not>E 1 0 0 0 0 0 0 0 0 \<le> e'\<close>
         using  defender_win_min_assms by force
       ultimately show  \<open>the (spectroscopy_moves g (Attacker_Immediate p' Q')) e = None\<close>
         using defender_win_min_assms(1) by force
@@ -321,12 +354,12 @@ next
         by (metis option.distinct(1) option.sel)
       thus \<open>the (spectroscopy_moves g (Defender_Conj p' Q')) e = None\<close> ..
     next
-      fix p' Q'
-      assume \<open>g' = Defender_Stable_Conj p' Q'\<close>
+      fix p' Q' Qr
+      assume \<open>g' = Defender_Stable_Conj p' Q' Qr\<close>
       hence False
         using Attacker_Delayed defender_win_min_assms(2,3) local.late_stbl_conj
         by (metis (no_types, lifting) option.distinct(1) option.sel)
-      thus \<open>the (spectroscopy_moves g (Defender_Stable_Conj p' Q')) e = None\<close> ..
+      thus \<open>the (spectroscopy_moves g (Defender_Stable_Conj p' Q' Qr)) e = None\<close> ..
     next
       fix p' p'' Q' \<alpha> Q\<alpha>
       assume \<open>g' = Defender_Branch p' \<alpha> p'' Q' Q\<alpha>\<close>
@@ -340,12 +373,12 @@ next
     hence \<open>(\<exists>q'\<in>Q'. g' = Attacker_Clause p q')
       \<or> (\<exists>Qa'. Qa \<mapsto>aS a Qa' \<and> g' = Attacker_Branch p' Qa')\<close>
       using defender_win_min_assms by (cases g', auto) (metis not_None_eq)+
-    hence \<open>(spectroscopy_moves g g') = (subtract 0 1 1 0 0 0 0 0) \<or>
-      (spectroscopy_moves g g') = Some (\<lambda>e. Option.bind ((subtract_fn 0 1 1 0 0 0 0 0) e) min1_6)\<close>
+    hence \<open>(spectroscopy_moves g g') = (subtract 0 1 1 0 0 0 0 0 0) \<or>
+      (spectroscopy_moves g g') = Some (\<lambda>e. Option.bind ((subtract_fn 0 1 1 0 0 0 0 0 0) e) min1_6)\<close>
       using Defender_Branch option.collapse[OF defender_win_min_assms(2)]
       by (cases g', auto)
     thus ?thesis
-      using defender_win_min_assms min_1_6_some
+      using defender_win_min_assms min_some
       by (smt (verit, best) bind.bind_lunit option.distinct(1) dual_order.trans option.sel)
   next
     case (Defender_Conj p Q)
@@ -353,10 +386,14 @@ next
       by (cases g', auto)
         (smt (verit, best) option.distinct(1) option.inject order.trans)+
   next
-    case (Defender_Stable_Conj x71 x72)
+    case (Defender_Stable_Conj p Q Qr)
     with defender_win_min_assms show ?thesis
-      by (cases g', simp_all del: leq_components)
-         (smt (verit) dual_order.trans option.discI option.sel)+
+      apply (cases g') apply (simp_all del: leq_components)
+      apply (smt (verit) energy.sel(4) le_zero_eq leq_components min_6_7_subtr_simp not_one_le_zero option.discI option.sel)
+      apply (smt (verit) bind.bind_lunit leq_components min.absorb2 min.bounded_iff min_some(1) option.discI option.sel)
+      by (smt (verit, best) dual_order.trans option.collapse option.distinct(1) option.inject)
+      (*by (cases g', simp_all del: leq_components)
+         (smt (verit) dual_order.trans option.discI option.sel)+*)
   qed
 qed
 

--- a/Spectroscopy_Game.thy
+++ b/Spectroscopy_Game.thy
@@ -86,7 +86,7 @@ fun spectroscopy_moves :: \<open>('s, 'a) spectroscopy_position \<Rightarrow> ('
 
   empty_stbl_conj_answer:
     \<open>spectroscopy_moves (Defender_Stable_Conj p Q Qr) (Defender_Conj p' Q')
-      = (if Q = {} \<and> Q = Q' \<and> p = p' then (subtract 0 0 0 1 0 0 0 0 1)
+      = (if Q' = {} \<and> p = p' then (subtract 0 0 0 1 0 0 0 0 1)
          else None)\<close> |
 
   br_conj:

--- a/Spectroscopy_Game.thy
+++ b/Spectroscopy_Game.thy
@@ -14,13 +14,14 @@ datatype ('s, 'a) spectroscopy_position =
          Attacker_Immediate (attacker_state: \<open>'s\<close>) (defender_states: \<open>'s set\<close>) |
          Attacker_Branch (attacker_state: \<open>'s\<close>) (defender_states: \<open>'s set\<close>) |
          Attacker_Clause (attacker_state: \<open>'s\<close>) (defender_state: \<open>'s\<close>) |
+         Attacker_Stable_Clause (attacker_state: \<open>'s\<close>) (defender_state: \<open>'s\<close>) |
          Attacker_Delayed (attacker_state: \<open>'s\<close>) (defender_states: \<open>'s set\<close>) |
 
          Defender_Branch (attacker_state: \<open>'s\<close>) (attack_action: \<open>'a\<close>)
                          (attacker_state_succ: \<open>'s\<close>) (defender_states: \<open>'s set\<close>)
                          (defender_branch_states: \<open>'s set\<close>) |
          Defender_Conj (attacker_state: \<open>'s\<close>) (defender_states: \<open>'s set\<close>) |
-         Defender_Stable_Conj (attacker_state: \<open>'s\<close>) (defender_states: \<open>'s set\<close>)
+         Defender_Stable_Conj (attacker_state: \<open>'s\<close>) (defender_states: \<open>'s set\<close>) (defender_revivals: \<open>'s set\<close>)
 
 context LTS_Tau begin
 
@@ -37,12 +38,12 @@ fun spectroscopy_moves :: \<open>('s, 'a) spectroscopy_position \<Rightarrow> ('
 
   observation:
     \<open>spectroscopy_moves (Attacker_Delayed p Q) (Attacker_Immediate p' Q')
-      = (if (\<exists>a. p \<mapsto>a a p' \<and> Q \<mapsto>aS a Q') then (subtract 1 0 0 0 0 0 0 0)
+      = (if (\<exists>a. p \<mapsto>a a p' \<and> Q \<mapsto>aS a Q') then (subtract 1 0 0 0 0 0 0 0 0)
          else None)\<close> |
 
   f_or_early_conj:
     \<open>spectroscopy_moves (Attacker_Immediate p Q) (Defender_Conj p' Q')
-      =(if (Q\<noteq>{} \<and> Q = Q' \<and> p = p') then (subtract 0 0 0 0 1 0 0 0)
+      =(if (Q\<noteq>{} \<and> Q = Q' \<and> p = p') then (subtract 0 0 0 0 1 0 0 0 0)
         else None)\<close> |
 
   late_inst_conj:
@@ -51,28 +52,41 @@ fun spectroscopy_moves :: \<open>('s, 'a) spectroscopy_position \<Rightarrow> ('
 
   conj_answer:
     \<open>spectroscopy_moves (Defender_Conj p Q) (Attacker_Clause p' q)
-      = (if p = p' \<and> q \<in> Q then (subtract 0 0 1 0 0 0 0 0) else None)\<close> |
+      = (if p = p' \<and> q \<in> Q then (subtract 0 0 1 0 0 0 0 0 0) else None)\<close> |
 
   pos_neg_clause:
     \<open>spectroscopy_moves (Attacker_Clause p q) (Attacker_Delayed p' Q')
       = (if (p = p') then
           (if {q} \<Zsurj>S Q' then Some min1_6 else None)
          else (if ({p} \<Zsurj>S Q'\<and> q=p')
-               then Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 1) e) min1_7) else None))\<close> |
+               then Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8) else None))\<close> |
+  pos_neg_stable_clause:
+    \<open>spectroscopy_moves (Attacker_Stable_Clause p q) (Attacker_Delayed p' Q')
+      = (if (p = p') then
+          (if Q' = {q} then Some min1_7 else None)
+         else if q = p' \<and> Q' = {p}
+               then Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8)
+         else None)\<close> |
 
   late_stbl_conj:
-    \<open>spectroscopy_moves (Attacker_Delayed p Q) (Defender_Stable_Conj p' Q')
-      = (if (p = p' \<and> Q' = { q \<in> Q. (\<nexists>q'. q \<mapsto>\<tau> q')} \<and> (\<nexists>p''. p \<mapsto>\<tau> p''))
+    \<open>spectroscopy_moves (Attacker_Delayed p Q) (Defender_Stable_Conj p' Q' Qr)
+      = (if (p = p' \<and> (\<nexists>p''. p \<mapsto>\<tau> p'')
+        \<and> Qr \<subseteq> { q \<in> Q. (\<nexists>q'. q \<mapsto>\<tau> q')} \<and> Q' = { q \<in> Q. (\<nexists>q'. q \<mapsto>\<tau> q')} - Qr)
           then Some Some else None)\<close> |
 
   conj_s_answer:
-    \<open>spectroscopy_moves (Defender_Stable_Conj p Q) (Attacker_Clause p' q)
-      = (if p = p' \<and> q \<in> Q then (subtract 0 0 0 1 0 0 0 0)
+    \<open>spectroscopy_moves (Defender_Stable_Conj p Q Qr) (Attacker_Stable_Clause p' q)
+      = (if p = p' \<and> q \<in> Q then Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 1 0 0 0 0 0) e) min6_7)
+         else None)\<close> |
+
+  conj_s_revival:
+    \<open>spectroscopy_moves (Defender_Stable_Conj p Q Qr) (Attacker_Delayed p' Q')
+      = (if p = p' \<and> Q' = Qr then Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 1 0 0 0 0 0) e) min1_6)
          else None)\<close> |
 
   empty_stbl_conj_answer:
-    \<open>spectroscopy_moves (Defender_Stable_Conj p Q) (Defender_Conj p' Q')
-      = (if Q = {} \<and> Q = Q' \<and> p = p' then (subtract 0 0 0 1 0 0 0 0)
+    \<open>spectroscopy_moves (Defender_Stable_Conj p Q Qr) (Defender_Conj p' Q')
+      = (if Q = {} \<and> Q = Q' \<and> p = p' then (subtract 0 0 0 1 0 0 0 0 1)
          else None)\<close> |
 
   br_conj:
@@ -82,16 +96,16 @@ fun spectroscopy_moves :: \<open>('s, 'a) spectroscopy_position \<Rightarrow> ('
 
   br_answer:
     \<open>spectroscopy_moves (Defender_Branch p \<alpha> p' Q Q\<alpha>) (Attacker_Clause p'' q)
-      = (if (p = p'' \<and> q \<in> Q) then (subtract 0 1 1 0 0 0 0 0) else None)\<close> |
+      = (if (p = p'' \<and> q \<in> Q) then (subtract 0 1 1 0 0 0 0 0 0) else None)\<close> |
 
   br_obsv:
     \<open>spectroscopy_moves (Defender_Branch p \<alpha> p' Q Q\<alpha>) (Attacker_Branch p'' Q')
       = (if (p' = p'' \<and> Q\<alpha> \<mapsto>aS \<alpha> Q')
-         then Some (\<lambda>e. Option.bind ((subtract_fn 0 1 1 0 0 0 0 0) e) min1_6) else None)\<close> |
+         then Some (\<lambda>e. Option.bind ((subtract_fn 0 1 1 0 0 0 0 0 0) e) min1_6) else None)\<close> |
 
   br_acct:
     \<open>spectroscopy_moves (Attacker_Branch p Q) (Attacker_Immediate p' Q')
-      = (if p = p' \<and> Q = Q' then subtract 1 0 0 0 0 0 0 0 else None)\<close> |
+      = (if p = p' \<and> Q = Q' then subtract 1 0 0 0 0 0 0 0 0 else None)\<close> |
 
   others: \<open>spectroscopy_moves _ _ = None\<close>
 
@@ -99,10 +113,11 @@ fun spectroscopy_defender where
   \<open>spectroscopy_defender (Attacker_Immediate _ _) = False\<close> |
   \<open>spectroscopy_defender (Attacker_Branch _ _) = False\<close> |
   \<open>spectroscopy_defender (Attacker_Clause _ _) = False\<close> |
+  \<open>spectroscopy_defender (Attacker_Stable_Clause _ _) = False\<close> |
   \<open>spectroscopy_defender (Attacker_Delayed _ _) = False\<close> |
   \<open>spectroscopy_defender (Defender_Branch _ _ _ _ _) = True\<close> |
   \<open>spectroscopy_defender (Defender_Conj _ _) = True\<close> |
-  \<open>spectroscopy_defender (Defender_Stable_Conj _ _) = True\<close>
+  \<open>spectroscopy_defender (Defender_Stable_Conj _ _ _) = True\<close>
 
 interpretation Game: energy_game \<open>spectroscopy_moves\<close> \<open>spectroscopy_defender\<close> \<open>(\<le>)\<close>
 proof
@@ -130,9 +145,10 @@ next
   next
     case (Attacker_Clause p q)
     hence \<open>\<exists>p' Q'. g'= (Attacker_Delayed p' Q')\<close>
-      using monotonicity_assms(1,2)
-      by (metis spectroscopy_defender.cases spectroscopy_moves.simps(22,23,26,46,62,67))
-    hence \<open>spectroscopy_moves g g' = Some min1_6 \<or> spectroscopy_moves g g' = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 1) e) min1_7)\<close>
+      using monotonicity_assms(1,2) 
+      by (induct, auto)
+    hence \<open>spectroscopy_moves g g' =
+      Some min1_6 \<or> spectroscopy_moves g g' = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8)\<close>
       using monotonicity_assms(1,2) Attacker_Clause
       by (smt (verit, ccfv_threshold) spectroscopy_moves.simps(7))
     thus ?thesis
@@ -143,9 +159,9 @@ next
         unfolding leq_components
         by (metis min_1_6_simps option.sel)
     next
-      assume \<open>spectroscopy_moves g g' = Some (\<lambda>e. Option.bind (if \<not> E 0 0 0 0 0 0 0 1 \<le> e then None else Some (e - E 0 0 0 0 0 0 0 1)) min1_7)\<close>
+      assume \<open>spectroscopy_moves g g' = Some (\<lambda>e. Option.bind (if \<not> E 0 0 0 0 0 0 0 0 1 \<le> e then None else Some (e - E 0 0 0 0 0 0 0 0 1)) min1_8)\<close>
       thus ?thesis
-        unfolding min_1_7_subtr_simp
+        unfolding min_1_8_subtr_simp
         using monotonicity_assms
         by (smt (z3) enat_diff_mono energy.sel leq_components min.mono option.distinct(1) option.sel)
     qed
@@ -154,9 +170,10 @@ next
     hence \<open>(\<exists>p' Q'. g'=(Attacker_Delayed p' Q')) \<or>
       (\<exists>p' Q'. g'=(Attacker_Immediate p' Q')) \<or>
       (\<exists>p' Q'. g'=(Defender_Conj p' Q')) \<or>
-      (\<exists>p' Q'. g'=(Defender_Stable_Conj p' Q')) \<or>
+      (\<exists>p' Q' Qr. g'=(Defender_Stable_Conj p' Q' Qr)) \<or>
       (\<exists>p' p'' Q' \<alpha> Q\<alpha> . g'= (Defender_Branch p' \<alpha> p'' Q' Q\<alpha>))\<close>
-      by (metis monotonicity_assms(1) spectroscopy_defender.cases spectroscopy_moves.simps(27,59))
+      using  monotonicity_assms(1)
+      by (induct, auto)
     thus ?thesis
     proof (safe)
       fix p' Q'
@@ -167,7 +184,7 @@ next
     next
       fix p' Q'
       assume \<open>g' = Attacker_Immediate p' Q'\<close>
-      hence \<open>spectroscopy_moves g g' = (subtract 1 0 0 0 0 0 0 0)\<close>
+      hence \<open>spectroscopy_moves g g' = (subtract 1 0 0 0 0 0 0 0 0)\<close>
         using Attacker_Delayed monotonicity_assms local.observation
         by (clarify, presburger)
       thus \<open>eu \<le> eu'\<close>
@@ -179,8 +196,8 @@ next
         using Attacker_Delayed monotonicity_assms local.late_inst_conj
         by (metis option.sel)
     next
-      fix p' Q'
-      assume \<open>g' = Defender_Stable_Conj p' Q'\<close>
+      fix p' Q' Qr
+      assume \<open>g' = Defender_Stable_Conj p' Q' Qr\<close>
       thus \<open>eu \<le> eu'\<close>
         using Attacker_Delayed monotonicity_assms local.late_stbl_conj
         by (metis (no_types, lifting) option.sel)
@@ -202,10 +219,36 @@ next
       by (cases g', simp_all del: leq_components)
         (smt (verit, ccfv_SIG) mono_subtract option.discI option.sel)
   next
-    case (Defender_Stable_Conj x71 x72)
-    with monotonicity_assms show ?thesis
-      by (cases g', simp_all del: leq_components)
-       (smt (verit, ccfv_SIG) mono_subtract option.discI option.sel)+
+    case (Defender_Stable_Conj p Q Qr)
+    with monotonicity_assms(1) show ?thesis
+    proof (cases g', auto simp del: leq_components)
+      case (Attacker_Stable_Clause p' q')
+      fix up
+      assume upd: \<open>(if p = p' \<and> q' \<in> Q then Some (\<lambda>e. Option.bind (if \<not> E 0 0 0 1 0 0 0 0 0 \<le> e then None else Some (e - E 0 0 0 1 0 0 0 0 0)) min6_7) else None) = Some up\<close>
+      hence \<open>up e = Some eu\<close> \<open>up e' = Some eu'\<close> using monotonicity_assms(2,3)
+        by (auto simp add: Attacker_Stable_Clause Defender_Stable_Conj)
+      then show ?thesis using monotonicity_assms(2,3,4) upd min_6_7_subtr_mono unfolding mono_def
+        apply (auto simp add: min_6_7_subtr_simp) 
+        apply (metis (no_types, lifting) energy.sel min_6_7_subtr_simp option.discI option.sel)
+        apply (metis (no_types, lifting) energy.sel min_6_7_subtr_simp option.discI option.sel)
+              apply (metis (no_types, lifting) energy.sel min_6_7_subtr_simp option.discI option.sel)
+        apply (metis (no_types, lifting) enat_diff_mono energy.sel(4) min_6_7_subtr_simp option.discI option.sel)
+        apply (metis (no_types, lifting) energy.collapse energy.inject min_6_7_subtr_simp option.distinct(1) option.sel)
+        apply (metis (no_types, lifting) energy.sel(6) min_6_7_subtr_simp option.discI option.sel)
+        apply (smt (verit) bind_eq_None_conv energy.sel(4) leq_components option.case_eq_if option.discI option.sel)
+        apply (metis (no_types, lifting) energy.sel(8) min_6_7_subtr_simp option.discI option.sel)
+        by (metis (no_types, lifting) energy.sel(9) min_6_7_subtr_simp option.discI option.sel)
+    next
+      case (Attacker_Delayed p' Q')
+      then show ?thesis using monotonicity_assms(2,3,4) sorry
+    next
+      case (Defender_Conj p' Q')
+      then show ?thesis using monotonicity_assms(2,3,4) apply (smt (verit, best) mono_subtract option.sel option.simps(3))
+    qed
+
+      apply (cases g', simp_all del: leq_components)
+      
+      apply (smt (verit, ccfv_SIG) mono_subtract option.discI option.sel)
   qed
 next
   fix g g' e e'

--- a/Strategy_Formulas.thy
+++ b/Strategy_Formulas.thy
@@ -42,17 +42,17 @@ where
   observation:
     \<open>strategy_formula_inner (Attacker_Delayed p Q) e (Obs \<alpha> \<phi>)\<close>
       if \<open>\<exists>p' Q'. spectroscopy_moves (Attacker_Delayed p Q) (Attacker_Immediate p' Q')
-         = (subtract 1 0 0 0 0 0 0 0)
-          \<and> attacker_wins (e - (E 1 0 0 0 0 0 0 0)) (Attacker_Immediate p' Q')
-          \<and> strategy_formula (Attacker_Immediate p' Q') (e - (E 1 0 0 0 0 0 0 0)) \<phi>
+         = (subtract 1 0 0 0 0 0 0 0 0)
+          \<and> attacker_wins (e - (E 1 0 0 0 0 0 0 0 0)) (Attacker_Immediate p' Q')
+          \<and> strategy_formula (Attacker_Immediate p' Q') (e - (E 1 0 0 0 0 0 0 0 0)) \<phi>
           \<and> p \<mapsto>a\<alpha> p' \<and> Q \<mapsto>aS \<alpha> Q'\<close> |
 
   early_conj:
     \<open>strategy_formula (Attacker_Immediate p Q) e \<phi>\<close>
       if \<open>\<exists>p'. spectroscopy_moves (Attacker_Immediate p Q) (Defender_Conj p' Q')
-                = (subtract 0 0 0 0 1 0 0 0)
-                  \<and> attacker_wins (e - (E 0 0 0 0 1 0 0 0)) (Defender_Conj p' Q')
-                  \<and> strategy_formula (Defender_Conj p' Q') (e - (E 0 0 0 0 1 0 0 0)) \<phi>\<close> |
+                = (subtract 0 0 0 0 1 0 0 0 0)
+                  \<and> attacker_wins (e - (E 0 0 0 0 1 0 0 0 0)) (Defender_Conj p' Q')
+                  \<and> strategy_formula (Defender_Conj p' Q') (e - (E 0 0 0 0 1 0 0 0 0)) \<phi>\<close> |
 
   late_conj:
     \<open>strategy_formula_inner (Attacker_Delayed p Q) e \<chi>\<close>

--- a/Strategy_Formulas.thy
+++ b/Strategy_Formulas.thy
@@ -113,14 +113,14 @@ where
     \<open>strategy_formula_conjunct (Attacker_Stable_Clause p q) e (Pos \<chi>)\<close>
       if \<open>spectroscopy_moves (Attacker_Stable_Clause p q) (Attacker_Delayed p {q}) = Some min1_7
         \<and> attacker_wins (the (min1_7 e)) (Attacker_Delayed p {q})
-        \<and> strategy_formula_inner (Attacker_Delayed p Q') (the (min1_7 e)) \<chi>\<close> |
+        \<and> strategy_formula_inner (Attacker_Delayed p {q}) (the (min1_7 e)) \<chi>\<close> |
 
   neg_stable:
     \<open>strategy_formula_conjunct (Attacker_Stable_Clause p q) e (Neg \<chi>)\<close>
       if \<open>spectroscopy_moves (Attacker_Stable_Clause p q) (Attacker_Delayed q {p})
             = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8)
           \<and> attacker_wins (the (min1_8 (e - (E 0 0 0 0 0 0 0 0 1)))) (Attacker_Delayed q {p})
-          \<and> strategy_formula_inner (Attacker_Delayed q P') (the (min1_8 (e - (E 0 0 0 0 0 0 0 0 1)))) \<chi>\<close> |
+          \<and> strategy_formula_inner (Attacker_Delayed q {p}) (the (min1_8 (e - (E 0 0 0 0 0 0 0 0 1)))) \<chi>\<close> |
 
   branch:
   \<open>strategy_formula_inner (Attacker_Delayed p Q) e \<chi>\<close>
@@ -865,8 +865,8 @@ lemma strategy_formulas_distinguish:
         (case g of
        Attacker_Delayed p Q \<Rightarrow> (Q \<Zsurj>S Q) \<longrightarrow> distinguishes_from (Internal \<chi>) p Q
       | Defender_Conj p Q \<Rightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q
-      | Defender_Stable_Conj p Q Qr \<Rightarrow> (\<forall>q. \<not> p \<mapsto> \<tau> q)
-          \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q
+      | Defender_Stable_Conj p Q Qr \<Rightarrow> stable_state p \<longrightarrow> (\<forall>q \<in> Q\<union>Qr. stable_state q)
+          \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p (Q\<union>Qr)
       | Defender_Branch p \<alpha> p' Q Qa \<Rightarrow>(p \<mapsto>a \<alpha> p')
           \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p (Q\<union>Qa)
       | _ \<Rightarrow> True))
@@ -874,7 +874,8 @@ lemma strategy_formulas_distinguish:
       (strategy_formula_conjunct g e \<psi> \<longrightarrow>
         (case g of
         Attacker_Clause p q \<Rightarrow> hml_srbb_conj.distinguishes \<psi> p q
-      | Attacker_Stable_Clause p q \<Rightarrow> hml_srbb_conj.distinguishes \<psi> p q
+      | Attacker_Stable_Clause p q \<Rightarrow>  stable_state p \<longrightarrow> stable_state q
+          \<longrightarrow> hml_srbb_conj.distinguishes \<psi> p q
       | _ \<Rightarrow> True))\<close>
 proof(induction rule: strategy_formula_strategy_formula_inner_strategy_formula_conjunct.induct)
   case (delay p Q e \<chi>)
@@ -885,33 +886,26 @@ next
   from this obtain p' where IH: \<open>spectroscopy_moves (Attacker_Delayed p Q) (Attacker_Delayed p' Q) = Some Some \<and>
        attacker_wins e (Attacker_Delayed p' Q) \<and>
        strategy_formula_inner (Attacker_Delayed p' Q) e \<chi> \<and>
-       (case Attacker_Delayed p' Q of Attacker_Delayed p Q \<Rightarrow> Q \<Zsurj>S Q \<longrightarrow> distinguishes_from (hml_srbb.Internal \<chi>) p Q
-        | Defender_Branch p \<alpha> p' Q Qa \<Rightarrow> p \<mapsto>\<alpha> p' \<and> Qa \<noteq> {} \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p (Q \<union> Qa)
-        | Defender_Conj p Q \<Rightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q
-        | Defender_Stable_Conj p Q \<Rightarrow> (\<forall>q. \<not> p \<mapsto>\<tau> q) \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q | _ \<Rightarrow> True)\<close> by fastforce
-  hence D: \<open>Q \<Zsurj>S Q \<longrightarrow> distinguishes_from (hml_srbb.Internal \<chi>) p' Q\<close>
-    using spectroscopy_position.simps(53) by fastforce
+       (Q \<Zsurj>S Q \<longrightarrow> distinguishes_from (hml_srbb.Internal \<chi>) p' Q)\<close> by fastforce
   from IH have \<open>p \<Zsurj>p'\<close>
     by (metis option.discI silent_reachable.intros(1) silent_reachable_append_\<tau> spectroscopy_moves.simps(2))
-  hence \<open>Q \<Zsurj>S Q \<longrightarrow> distinguishes_from (hml_srbb.Internal \<chi>) p Q\<close> using D
+  hence \<open>Q \<Zsurj>S Q \<longrightarrow> distinguishes_from (hml_srbb.Internal \<chi>) p Q\<close> using IH
     by (smt (verit) LTS_Tau.silent_reachable_trans distinguishes_from_def hml_srbb_models.simps(2))
   then show ?case by simp
 next
   case (observation p Q e \<phi> \<alpha>)
-  then obtain p' Q' where IH: \<open>spectroscopy_moves (Attacker_Delayed p Q) (Attacker_Immediate p' Q') = subtract 1 0 0 0 0 0 0 0 \<and>
-     attacker_wins (e - E 1 0 0 0 0 0 0 0) (Attacker_Immediate p' Q') \<and>
-     (strategy_formula (Attacker_Immediate p' Q') (e - E 1 0 0 0 0 0 0 0) \<phi> \<and>
-      (case Attacker_Immediate p' Q' of Attacker_Immediate p Q \<Rightarrow> distinguishes_from \<phi> p Q
-       | Defender_Conj p Q \<Rightarrow> distinguishes_from \<phi> p Q | _ \<Rightarrow> True)) \<and>
+  then obtain p' Q' where IH: \<open>spectroscopy_moves (Attacker_Delayed p Q) (Attacker_Immediate p' Q') = subtract 1 0 0 0 0 0 0 0 0 \<and>
+     attacker_wins (e - E 1 0 0 0 0 0 0 0 0) (Attacker_Immediate p' Q') \<and>
+     strategy_formula (Attacker_Immediate p' Q') (e - E 1 0 0 0 0 0 0 0 0) \<phi> \<and>
+     distinguishes_from \<phi> p' Q' \<and>
      p \<mapsto>a \<alpha> p' \<and> Q \<mapsto>aS \<alpha> Q'\<close> by auto
-  hence D: \<open>distinguishes_from \<phi> p' Q'\<close> by auto
   hence \<open>p' \<Turnstile>SRBB \<phi>\<close> by auto
 
   have observation: \<open>spectroscopy_moves (Attacker_Delayed p Q) (Attacker_Immediate p' Q')
-      = (if (\<exists>a. p \<mapsto>a a p' \<and> Q \<mapsto>aS a Q') then (subtract 1 0 0 0 0 0 0 0) else None)\<close>
+      = (if (\<exists>a. p \<mapsto>a a p' \<and> Q \<mapsto>aS a Q') then (subtract 1 0 0 0 0 0 0 0 0) else None)\<close>
     for p p' Q Q' by simp
   from IH have \<open>spectroscopy_moves (Attacker_Delayed p Q) (Attacker_Immediate p' Q')
-    = subtract 1 0 0 0 0 0 0 0\<close> by simp
+    = subtract 1 0 0 0 0 0 0 0 0\<close> by simp
   also have \<open>... \<noteq> None\<close> by blast
   finally have \<open>(\<exists>a. p \<mapsto>a a p' \<and> Q \<mapsto>aS a Q')\<close> unfolding observation by metis
 
@@ -934,7 +928,7 @@ next
     hence \<open>\<exists>q''\<in>Q'. q' \<mapsto>a \<alpha> q'' \<and> q'' \<Turnstile>SRBB \<phi>\<close>
       using \<open>Q \<mapsto>aS \<alpha> Q'\<close> \<open>hml_srbb_inner_models q' (Obs \<alpha> \<phi>)\<close> by auto
     then obtain q'' where \<open>q''\<in>Q'\<and> q' \<mapsto>a \<alpha> q'' \<and> q'' \<Turnstile>SRBB \<phi>\<close> by auto
-    thus \<open>False\<close> using D by auto
+    thus \<open>False\<close> using IH by auto
   qed
   hence \<open>Q \<Zsurj>S Q \<longrightarrow> distinguishes_from (hml_srbb.Internal (hml_srbb_inner.Obs \<alpha> \<phi>)) p Q\<close>
     using P by fastforce
@@ -961,13 +955,10 @@ next
 next
   case (neg p q e \<chi>)
   then obtain P' where IH:
-    \<open>spectroscopy_moves (Attacker_Clause p q) (Attacker_Delayed q P') =  Some (\<lambda>e. Option.bind (subtract_fn 0 0 0 0 0 0 0 1 e) min1_7)\<close>
-    \<open>attacker_wins (the (min1_7 (e - E 0 0 0 0 0 0 0 1))) (Attacker_Delayed q P') \<and>
-       strategy_formula_inner (Attacker_Delayed q P') (the (min1_7 (e - E 0 0 0 0 0 0 0 1))) \<chi> \<and>
-       (case Attacker_Delayed q P' of Attacker_Delayed p Q \<Rightarrow> Q \<Zsurj>S Q \<longrightarrow> distinguishes_from (hml_srbb.Internal \<chi>) p Q
-        | Defender_Branch p \<alpha> p' Q Qa \<Rightarrow> p \<mapsto>\<alpha> p' \<and> Qa \<noteq> {} \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p (Q \<union> Qa)
-        | Defender_Conj p Q \<Rightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q
-        | Defender_Stable_Conj p Q \<Rightarrow> (\<forall>q. \<not> p \<mapsto>\<tau> q) \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q | _ \<Rightarrow> True)\<close> by fastforce
+    \<open>spectroscopy_moves (Attacker_Clause p q) (Attacker_Delayed q P') =  Some (\<lambda>e. Option.bind (subtract_fn 0 0 0 0 0 0 0 0 1 e) min1_8)\<close>
+    \<open>attacker_wins (the (min1_8 (e - E 0 0 0 0 0 0 0 0 1))) (Attacker_Delayed q P') \<and>
+       strategy_formula_inner (Attacker_Delayed q P') (the (min1_8 (e - E 0 0 0 0 0 0 0 0 1))) \<chi> \<and>
+       (P' \<Zsurj>S P' \<longrightarrow> distinguishes_from (hml_srbb.Internal \<chi>) q P')\<close> by fastforce
   hence D: \<open>P' \<Zsurj>S P' \<longrightarrow> distinguishes_from (hml_srbb.Internal \<chi>) q P'\<close> by simp
   have \<open>{p} \<Zsurj>S P'\<close> using IH(1) spectroscopy_moves.simps
     by (metis (no_types, lifting) not_Some_eq)
@@ -978,18 +969,20 @@ next
   then show ?case by simp
 next
   case (stable p Q e \<chi>)
-  then obtain Q' where IH: \<open>spectroscopy_moves (Attacker_Delayed p Q) (Defender_Stable_Conj p Q') = Some Some\<close>
-       \<open>attacker_wins e (Defender_Stable_Conj p Q') \<and>
-       strategy_formula_inner (Defender_Stable_Conj p Q') e \<chi> \<and>
-       (case Defender_Stable_Conj p Q' of Attacker_Delayed p Q \<Rightarrow> Q \<Zsurj>S Q \<longrightarrow> distinguishes_from (hml_srbb.Internal \<chi>) p Q
-        | Defender_Branch p \<alpha> p' Q Qa \<Rightarrow> p \<mapsto>\<alpha> p' \<and> Qa \<noteq> {} \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p (Q \<union> Qa)
-        | Defender_Conj p Q \<Rightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q
-        | Defender_Stable_Conj p Q \<Rightarrow> (\<forall>q. \<not> p \<mapsto>\<tau> q) \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q | _ \<Rightarrow> True)\<close> by auto
-  hence \<open>(\<nexists>p''. p \<mapsto>\<tau> p'')\<close>
-    by (metis local.late_stbl_conj option.distinct(1))
-
-  from IH have \<open>(\<forall>q. \<not> p \<mapsto>\<tau> q) \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q'\<close> by simp
-  hence \<open>hml_srbb_inner.distinguishes_from \<chi> p Q'\<close> using \<open>\<nexists>p''. p \<mapsto>\<tau> p''\<close> by auto
+  then obtain Q' Qr where IH: \<open>spectroscopy_moves (Attacker_Delayed p Q) (Defender_Stable_Conj p Q' Qr) = Some Some\<close>
+       \<open>attacker_wins e (Defender_Stable_Conj p Q' Qr) \<and>
+       strategy_formula_inner (Defender_Stable_Conj p Q' Qr) e \<chi> \<and>
+       (stable_state p \<longrightarrow> (\<forall>q \<in> Q'\<union>Qr. stable_state q)
+          \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p (Q'\<union>Qr))\<close> by auto
+  hence \<open>stable_state p\<close>
+    using late_stbl_conj
+    by (metis option.distinct(1))
+  moreover from IH have \<open>\<forall>q \<in> Q'\<union>Qr. stable_state q\<close>
+    unfolding late_stbl_conj
+    by (metis (no_types, lifting) Un_Diff_cancel2 mem_Collect_eq option.discI sup.orderE)
+  moreover from IH have \<open>stable_state p \<longrightarrow> (\<forall>q \<in> Q'\<union>Qr. stable_state q)
+      \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p (Q' \<union> Qr)\<close> by simp
+  ultimately have \<open>hml_srbb_inner.distinguishes_from \<chi> p (Q'\<union>Qr)\<close> by auto
   hence \<open>hml_srbb_inner_models p \<chi>\<close> by simp
   hence \<open>p \<Turnstile>SRBB (hml_srbb.Internal \<chi>)\<close>
     using LTS_Tau.refl by force
@@ -1004,20 +997,22 @@ next
       then obtain q' where X: \<open>q \<Zsurj> q' \<and> hml_srbb_inner_models q' \<chi>\<close> by auto
       hence \<open>q' \<in> Q\<close> using \<open>Q \<Zsurj>S Q\<close> \<open>q \<in> Q\<close> by blast
       then show \<open>False\<close>
-      proof (cases \<open>q' \<in> Q'\<close>)
+      proof (cases \<open>q' \<in> (Q'\<union>Qr)\<close>)
         case True (* stable cases *)
-        thus \<open>False\<close> using X \<open>hml_srbb_inner.distinguishes_from \<chi> p Q'\<close>
+        thus \<open>False\<close> using X \<open>hml_srbb_inner.distinguishes_from \<chi> p (Q'\<union>Qr)\<close>
           by simp
       next
         case False (* unstable cases *)
-        from IH have \<open>strategy_formula_inner (Defender_Stable_Conj p Q') e \<chi>\<close> by simp
-        hence \<open>\<exists>\<Phi>. \<chi>=(StableConj Q' \<Phi>)\<close> using strategy_formula_inner.simps
-          by (smt (verit) spectroscopy_position.distinct(35) spectroscopy_position.distinct(39) spectroscopy_position.distinct(41) spectroscopy_position.inject(7))
-        then obtain \<Phi> where P: \<open>\<chi>=(StableConj Q' \<Phi>)\<close> by auto
-        from IH(1) have \<open>Q' = { q \<in> Q. (\<nexists>q'. q \<mapsto>\<tau> q')}\<close>
-          by (metis (full_types) local.late_stbl_conj option.distinct(1))
+        from IH have \<open>strategy_formula_inner (Defender_Stable_Conj p Q' Qr) e \<chi>\<close> by simp
+        hence \<open>\<exists>\<Psi>. \<chi> = StableConj ({None} \<union> Some ` Q') \<Psi>\<close>
+          unfolding strategy_formula_inner.simps[of \<open>Defender_Stable_Conj p Q' Qr\<close> e \<chi>]
+          by blast
+        then obtain \<Psi> where P: \<open>\<chi> = StableConj ({None} \<union> Some ` Q') \<Psi>\<close> by blast
+        from IH(1) have \<open>(Q' \<union> Qr) = { q \<in> Q. (\<nexists>q'. q \<mapsto>\<tau> q')}\<close>
+          unfolding late_stbl_conj
+          by (metis (no_types, lifting) Un_Diff_cancel2 option.discI sup.orderE)
         hence \<open>\<exists>q''. q' \<mapsto>\<tau> q''\<close> using False \<open>q' \<in> Q\<close> by simp
-        from X have \<open>hml_srbb_inner_models q' (StableConj Q' \<Phi>)\<close> using P by auto
+        from X have \<open>hml_srbb_inner_models q' (StableConj ({None} \<union> Some ` Q') \<Psi>)\<close> using P by auto
         then show ?thesis using \<open>\<exists>q''. q' \<mapsto>\<tau> q''\<close> by simp
       qed
     qed
@@ -1026,22 +1021,53 @@ next
   qed
   then show ?case by simp
 next
-  case (stable_conj Q p e \<Phi>)
-  hence IH: \<open>\<forall>q\<in> Q. hml_srbb_conj.distinguishes (\<Phi> q) p q\<close> by simp
-  hence Q: \<open>\<forall>q \<in> Q. hml_srbb_conjunct_models p (\<Phi> q)\<close> by simp
-  hence \<open>(\<forall>q. \<not> p \<mapsto>\<tau> q) \<longrightarrow> hml_srbb_inner.distinguishes_from (StableConj Q \<Phi>) p Q\<close>
-    using IH by auto
-  then show ?case by simp
+  case (stable_conj \<Psi> p Q Qr e)
+  have \<open>stable_state p \<longrightarrow> ((\<forall>q \<in> Q\<union>Qr. stable_state q)) \<longrightarrow>
+    hml_srbb_inner.distinguishes_from (StableConj ({None} \<union> Some ` Q) \<Psi>) p (Q \<union> Qr)\<close>
+  proof safe
+    assume stability:
+      \<open>stable_state p\<close>
+      \<open>(\<forall>q \<in> Q\<union>Qr. stable_state q)\<close>
+    hence \<open>Qr \<Zsurj>S Qr\<close>
+      using silent_reachable.refl stable_state_stable by blast
+    with stable_conj obtain \<chi> where
+      \<open>\<Psi> None = Pos \<chi>\<close>
+      \<open>distinguishes_from (Internal \<chi>) p Qr\<close>
+      by auto
+    hence qr_distinction: \<open>hml_srbb_conj.distinguishes_from (Pos \<chi>) p Qr\<close> by auto
+    moreover have \<open>\<forall>q\<in> Q. hml_srbb_conj.distinguishes (\<Psi> (Some q)) p q\<close>
+      using stable_conj stability by simp
+    ultimately 
+      show \<open>hml_srbb_inner.distinguishes_from (StableConj ({None} \<union> Some ` Q) \<Psi>) p (Q \<union> Qr)\<close>
+      using \<open>\<Psi> None = Pos \<chi>\<close> stability by auto
+  qed
+  thus ?case by auto
+next
+  case (pos_stable p q e \<chi>)
+  then show ?case using silent_reachable.refl stable_state_stable by auto
+next
+  case (neg_stable p q e \<chi>)
+  show ?case
+  proof (clarsimp)
+    assume \<open>stable_state p\<close> \<open>stable_state q\<close>
+    hence IH:
+      \<open>spectroscopy_moves (Attacker_Clause p q) (Attacker_Delayed q {p}) = 
+        Some (\<lambda>e. Option.bind (subtract_fn 0 0 0 0 0 0 0 0 1 e) min1_8)\<close>
+      \<open>attacker_wins (the (min1_8 (e - E 0 0 0 0 0 0 0 0 1))) (Attacker_Delayed q {p}) \<and>
+         strategy_formula_inner (Attacker_Delayed q {p}) (the (min1_8 (e - E 0 0 0 0 0 0 0 0 1))) \<chi> \<and>
+         ({p} \<Zsurj>S {p} \<longrightarrow> distinguishes_from (Internal \<chi>) q {p})\<close>
+      using neg_stable silent_reachable.refl stable_state_stable by (auto, blast+)
+    thus \<open>(\<forall>p'. p \<Zsurj> p' \<longrightarrow> \<not> hml_srbb_inner_models p' \<chi>) \<and> (\<exists>p'. q \<Zsurj> p' \<and> hml_srbb_inner_models p' \<chi>)\<close>
+      using \<open>stable_state p\<close> distinguishes_from_def silent_reachable.refl singleton_iff stable_state_stable
+      by fastforce
+  qed
 next
   case (branch p Q e \<chi>)
   then obtain p' Q' \<alpha> Q\<alpha> where IH:
     \<open>spectroscopy_moves (Attacker_Delayed p Q) (Defender_Branch p \<alpha> p' Q' Q\<alpha>) = Some Some\<close>
     \<open>attacker_wins e (Defender_Branch p \<alpha> p' Q' Q\<alpha>) \<and>
      strategy_formula_inner (Defender_Branch p \<alpha> p' Q' Q\<alpha>) e \<chi> \<and>
-     (case Defender_Branch p \<alpha> p' Q' Q\<alpha> of Attacker_Delayed p Q \<Rightarrow> Q \<Zsurj>S Q \<longrightarrow> distinguishes_from (Internal \<chi>) p Q
-      | Defender_Branch p \<alpha> p' Q Qa \<Rightarrow> p \<mapsto>a \<alpha> p' \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p (Q \<union> Qa)
-      | Defender_Conj p Q \<Rightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q
-      | Defender_Stable_Conj p Q \<Rightarrow> (\<forall>q. \<not> p \<mapsto>\<tau> q) \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q | _ \<Rightarrow> True)\<close> by blast
+     (p \<mapsto>a \<alpha> p' \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p (Q' \<union> Q\<alpha>))\<close> by auto
   from IH(1) have \<open>p \<mapsto>a \<alpha> p'\<close>
     by (metis local.br_conj option.distinct(1))
   from IH have \<open>p \<mapsto>a \<alpha> p' \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p (Q' \<union> Q\<alpha>)\<close> by simp
@@ -1056,10 +1082,10 @@ next
   hence A1: \<open>\<forall>q\<in>Q1. hml_srbb_conjunct_models p (\<Phi> q)\<close> by simp
   from branch_conj obtain Q' where IH:
     \<open>spectroscopy_moves (Defender_Branch p \<alpha> p' Q1 Q\<alpha>) (Attacker_Branch p' Q')
-      = Some (\<lambda>e. Option.bind (subtract_fn 0 1 1 0 0 0 0 0 e) min1_6)\<close>
-    \<open>spectroscopy_moves (Attacker_Branch p' Q') (Attacker_Immediate p' Q') = subtract 1 0 0 0 0 0 0 0 \<and>
-     attacker_wins (the (min1_6 (e - E 0 1 1 0 0 0 0 0)) - E 1 0 0 0 0 0 0 0) (Attacker_Immediate p' Q') \<and>
-     strategy_formula (Attacker_Immediate p' Q') (the (min1_6 (e - E 0 1 1 0 0 0 0 0)) - E 1 0 0 0 0 0 0 0) \<psi> \<and>
+      = Some (\<lambda>e. Option.bind (subtract_fn 0 1 1 0 0 0 0 0 0 e) min1_6)\<close>
+    \<open>spectroscopy_moves (Attacker_Branch p' Q') (Attacker_Immediate p' Q') = subtract 1 0 0 0 0 0 0 0 0 \<and>
+     attacker_wins (the (min1_6 (e - E 0 1 1 0 0 0 0 0 0)) - E 1 0 0 0 0 0 0 0 0) (Attacker_Immediate p' Q') \<and>
+     strategy_formula (Attacker_Immediate p' Q') (the (min1_6 (e - E 0 1 1 0 0 0 0 0 0)) - E 1 0 0 0 0 0 0 0 0) \<psi> \<and>
      (case Attacker_Immediate p' Q' of Attacker_Immediate p Q \<Rightarrow> distinguishes_from \<psi> p Q
           | Defender_Conj p Q \<Rightarrow> distinguishes_from \<psi> p Q | _ \<Rightarrow> True)\<close> by auto
   hence \<open>distinguishes_from \<psi> p' Q'\<close> by simp

--- a/Strategy_Formulas.thy
+++ b/Strategy_Formulas.thy
@@ -98,11 +98,11 @@ where
   stable_conj:
     \<open>strategy_formula_inner (Defender_Stable_Conj p Q Qr) e (StableConj ({None} \<union> (Some ` Q)) \<Psi>)\<close>
       if
-        \<open>\<exists>\<phi>. (\<Psi> None) = Pos \<phi> 
+        \<open>\<exists>\<chi>. (\<Psi> None) = Pos \<chi> 
           \<and> spectroscopy_moves (Defender_Stable_Conj p Q Qr) (Attacker_Delayed p Qr)
             = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 1 0 0 0 0 0) e) min1_6)
           \<and> attacker_wins (the (min1_6 (e - (E 0 0 0 1 0 0 0 0 0)))) (Attacker_Delayed p Qr)
-          \<and> strategy_formula_inner (Attacker_Delayed q P') (the (min1_6 (e - (E 0 0 0 1 0 0 0 0 0)))) \<phi>\<close> 
+          \<and> strategy_formula_inner (Attacker_Delayed p Qr) (the (min1_6 (e - (E 0 0 0 1 0 0 0 0 0)))) \<chi>\<close> 
         \<open>\<forall>q \<in> Q.
           spectroscopy_moves (Defender_Stable_Conj p Q Qr) (Attacker_Stable_Clause p q)
             = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 1 0 0 0 0 0) e) min6_7)
@@ -749,84 +749,92 @@ next
         \<open>(\<exists>e'. weight (Defender_Stable_Conj p Q Qr) g' e = Some e' \<and> attacker_wins e' g') \<and> ((\<exists>q\<in>Q. g' = Attacker_Stable_Clause p q) \<or> g' = Attacker_Delayed p Qr \<or> g' = Defender_Conj p {})\<close>
         ..
     qed
+    have \<open>weight (Defender_Stable_Conj p Q Qr) (Defender_Conj p {}) = subtract_fn 0 0 0 1 0 0 0 0 1\<close>
+      by simp
+    hence e_not_low: \<open>E 0 0 0 1 0 0 0 0 1 \<le> e\<close>
+      using cases local.empty_stbl_conj_answer
+      by (metis (no_types, lifting) option.distinct(1))
     have \<open>\<exists>\<chi>. strategy_formula_inner (Defender_Stable_Conj p Q Qr) e \<chi> \<and> expr_pr_inner \<chi> \<le> e\<close>
-    proof
-      obtain e' where e'_spec:
-        \<open>e' = e - (E 0 0 0 1 0 0 0 0 0)\<close>
+    proof -
+      have moves: \<open>\<forall>g'. spectroscopy_moves (Defender_Stable_Conj p Q Qr) g' \<noteq> None \<longrightarrow>
+         (\<exists>e'. weight (Defender_Stable_Conj p Q Qr) g' e = Some e' \<and> attacker_wins e' g')\<close>
+        using cases by simp
+      hence
+        \<open>\<forall>q \<in> Q. weight (Defender_Stable_Conj p Q Qr) (Attacker_Stable_Clause p q) e = Option.bind ((subtract_fn 0 0 0 1 0 0 0 0 0) e) min6_7
+          \<and> attacker_wins (the (Option.bind ((subtract_fn 0 0 0 1 0 0 0 0 0) e) min6_7)) (Attacker_Stable_Clause p q)\<close>
+        using local.conj_s_answer
+        by (metis (no_types, lifting) option.discI option.sel)
+      then obtain e' where e'_spec:
+        \<open>Some e' = Option.bind ((subtract_fn 0 0 0 1 0 0 0 0 0) e) min6_7\<close>
         \<open>\<forall>q \<in> Q. weight (Defender_Stable_Conj p Q Qr) (Attacker_Stable_Clause p q) e = Some e'
           \<and> attacker_wins e' (Attacker_Stable_Clause p q)\<close>
-        using cases local.conj_s_answer
-        by (smt (verit, del_insts) option.distinct(1) option.sel)
-      hence IH: \<open>\<forall>q \<in> Q. \<exists>\<psi>.
-        strategy_formula_conjunct (Attacker_Clause p q) e' \<psi> \<and>
+        by (smt (z3) bind_eq_None_conv dual_order.trans e_not_low le_numeral_extra(4)
+            leq_components_constr min_some(4) option.collapse option.discI zero_le)
+      hence \<open>pos_conjuncts_sec e' \<le> pos_conjuncts e'\<close>
+        by (metis e'_spec(1) energy.sel(6) energy.sel(7) min_6_7_subtr_simp
+            min_def option.discI option.sel order_le_less)
+      with e'_spec have IH: \<open>\<forall>q \<in> Q. \<exists>\<psi>.
+        strategy_formula_conjunct (Attacker_Stable_Clause p q) e' \<psi> \<and>
         expr_pr_conjunct \<psi> \<le> e'\<close>
-        using Defender_Stable_Conj local.conj_s_answer
-        by (smt (verit, best) option.distinct(1) option.inject spectroscopy_position.simps(52))
-      hence \<open>\<exists>\<Phi>. \<forall>q \<in> Q.
-        strategy_formula_conjunct (Attacker_Clause p q) e' (\<Phi> q) \<and>
-        expr_pr_conjunct (\<Phi> q) \<le> e'\<close>
+        using Defender_Stable_Conj(2)[rule_format, of \<open>Attacker_Stable_Clause p _\<close>] local.conj_s_answer
+        unfolding min_6_7_subtr_simp
+        by fastforce
+      hence \<open>\<exists>\<Psi>. \<forall>q \<in> Q.
+        strategy_formula_conjunct (Attacker_Stable_Clause p q) e' (\<Psi> q) \<and>
+        expr_pr_conjunct (\<Psi> q) \<le> e'\<close>
         by meson
-      then obtain \<Phi> where \<Phi>_prop: \<open>\<forall>q \<in> Q.
-        strategy_formula_conjunct (Attacker_Clause p q) e' (\<Phi> q)
-        \<and> expr_pr_conjunct (\<Phi> q) \<le> e'\<close>
+      then obtain \<Psi> where \<Psi>_prop: \<open>\<forall>q \<in> Q.
+        strategy_formula_conjunct (Attacker_Stable_Clause p q) e' (\<Psi> q)
+        \<and> expr_pr_conjunct (\<Psi> q) \<le> e'\<close>
         by blast
-      have \<open>E 0 0 0 1 0 0 0 0 \<le> e\<close>
-        using e'_spec False by fastforce
-      hence \<open>expr_pr_inner (StableConj Q \<Phi>) \<le> e\<close>
-        using expr_st_conj e'_spec \<Phi>_prop False by metis
-      moreover have \<open>strategy_formula_inner (Defender_Stable_Conj p Q) e (StableConj Q \<Phi>)\<close>
-        using \<Phi>_prop e'_spec stable_conj
-        unfolding e'_spec by fastforce
-      ultimately show ?thesis by auto
-    thus ?case by simp
-    proof(cases \<open>Q = {} \<and> Qr = {}\<close>)
-      case True
-      then obtain e' where e'_spec:
-        \<open>weight (Defender_Stable_Conj p Q Qr) (Defender_Conj p Q) e = Some e'\<close>
-        \<open>e' = e - (E 0 0 0 1 0 0 0 0 0)\<close>
-        \<open>attacker_wins e' (Defender_Conj p Q)\<close>
-        using cases local.empty_stbl_conj_answer
-        by (smt (verit, best) option.discI option.sel)
-      then obtain \<Phi> where \<Phi>_prop: \<open>strategy_formula_inner (Defender_Conj p Q) e' (Conj Q \<Phi>)\<close>
-        using conj True by blast
-      hence strategy: \<open>strategy_formula_inner (Defender_Stable_Conj p Q) e (StableConj Q \<Phi>)\<close>
-        by (simp add: True stable_conj)
-      have \<open>E 0 0 0 1 0 0 0 0 \<le> e\<close> using e'_spec
-        using option.sel True by fastforce
-      moreover have \<open>expr_pr_inner (StableConj Q \<Phi>) = E 0 0 0 1 0 0 0 0\<close>
-        using True by (simp add: bot_enat_def)
-      ultimately have \<open>expr_pr_inner (StableConj Q \<Phi>) \<le> e\<close> by simp
-      with strategy show ?thesis by auto
-    next
-      case False
-      then obtain e' where e'_spec:
-        \<open>e' = e - (E 0 0 0 1 0 0 0 0)\<close>
-        \<open>\<forall>q \<in> Q. weight (Defender_Stable_Conj p Q) (Attacker_Clause p q) e = Some e'
-          \<and> attacker_wins e' (Attacker_Clause p q)\<close>
-        using cases local.conj_s_answer
-        by (smt (verit, del_insts) option.distinct(1) option.sel)
-      hence IH: \<open>\<forall>q \<in> Q. \<exists>\<psi>.
-        strategy_formula_conjunct (Attacker_Clause p q) e' \<psi> \<and>
-        expr_pr_conjunct \<psi> \<le> e'\<close>
-        using Defender_Stable_Conj local.conj_s_answer
-        by (smt (verit, best) option.distinct(1) option.inject spectroscopy_position.simps(52))
-      hence \<open>\<exists>\<Phi>. \<forall>q \<in> Q.
-        strategy_formula_conjunct (Attacker_Clause p q) e' (\<Phi> q) \<and>
-        expr_pr_conjunct (\<Phi> q) \<le> e'\<close>
-        by meson
-      then obtain \<Phi> where \<Phi>_prop: \<open>\<forall>q \<in> Q.
-        strategy_formula_conjunct (Attacker_Clause p q) e' (\<Phi> q)
-        \<and> expr_pr_conjunct (\<Phi> q) \<le> e'\<close>
+      obtain e\<chi>' where e\<chi>'_spec:
+        \<open>Some e\<chi>' = Option.bind ((subtract_fn 0 0 0 1 0 0 0 0 0) e) min1_6\<close>
+        \<open>weight (Defender_Stable_Conj p Q Qr) (Attacker_Delayed p Qr) e = Some e\<chi>'\<close>
+        \<open>attacker_wins e\<chi>' (Attacker_Delayed p Qr)\<close>
+        using moves by force
+      then obtain \<chi> where \<chi>_spec:
+        \<open>strategy_formula_inner (Attacker_Delayed p Qr) e\<chi>' \<chi>\<close>
+        \<open>expr_pr_inner \<chi> \<le> e\<chi>'\<close>
+        using Defender_Stable_Conj conj_s_revival spectroscopy_position.simps
+        by (smt (verit, best) option.discI option.inject)
+      hence \<chi>e: \<open>expr_pr_conjunct (Pos \<chi>) \<le> the (min1_6 e)\<close> sorry
+      hence \<open>modal_depth_srbb_inner \<chi> \<le> pos_conjuncts e\<close> by simp
+      hence \<open>\<forall>q\<in>Q. \<exists>\<chi>q. \<Psi> q = Pos \<chi>q \<longrightarrow> modal_depth_srbb_inner \<chi>q \<le> pos_conjuncts e\<close> by blast
+      obtain e'' where e''_spec: \<open>subtract_fn  0 0 0 1 0 0 0 0 0 e = Some e''\<close>
+        using e_not_low by auto
+      define \<Psi>\<chi> where
+        \<open>\<Psi>\<chi> \<equiv> \<lambda>qn. case qn of None \<Rightarrow> Pos \<chi> | Some q \<Rightarrow> \<Psi> q\<close>
+      define rQ where
+        \<open>rQ \<equiv> {None} \<union> Some ` Q\<close>
+      have \<open>\<forall>qn \<in> rQ. expr_pr_conjunct (\<Psi>\<chi> qn) \<le> e''\<close>
+        using \<Psi>_prop e'_spec e''_spec \<chi>e e\<chi>'_spec \<chi>_spec leq_components e_not_low
+        unfolding \<Psi>\<chi>_def rQ_def
+        by (simp, smt (z3) bind.bind_lunit energy.sel min.bounded_iff min_1_6_simps min_6_7_simps option.sel)
+      moreover have \<open>\<forall>qn \<in> rQ - revival_conjunct_index rQ \<Psi>\<chi>. is_pos (\<Psi>\<chi> qn) \<longrightarrow> modal_depth_srbb_conjunct (\<Psi>\<chi> qn) \<le> pos_conjuncts_sec e''\<close>
+        unfolding revival_conjunct_index_def sorry
+      moreover have \<open>0 < neg_depth e\<close> using e_not_low by auto
+      ultimately have price_bound: \<open>expr_pr_inner (StableConj rQ \<Psi>\<chi>) \<le> e\<close>
+        using expr_st_conj[OF e''_spec, of rQ \<Psi>\<chi>]
         by blast
-      have \<open>E 0 0 0 1 0 0 0 0 \<le> e\<close>
-        using e'_spec False by fastforce
-      hence \<open>expr_pr_inner (StableConj Q \<Phi>) \<le> e\<close>
-        using expr_st_conj e'_spec \<Phi>_prop False by metis
-      moreover have \<open>strategy_formula_inner (Defender_Stable_Conj p Q) e (StableConj Q \<Phi>)\<close>
-        using \<Phi>_prop e'_spec stable_conj
-        unfolding e'_spec by fastforce
-      ultimately show ?thesis by auto
+      have \<open>\<Psi>\<chi> None = Pos \<chi>\<close>
+         \<open>spectroscopy_moves (Defender_Stable_Conj p Q Qr) (Attacker_Delayed p Qr) = Some (\<lambda>e. Option.bind (if \<not> E 0 0 0 1 0 0 0 0 0 \<le> e then None else Some (e - E 0 0 0 1 0 0 0 0 0)) min1_6)\<close>
+         \<open>attacker_wins (the (min1_6 (e - E 0 0 0 1 0 0 0 0 0))) (Attacker_Delayed p Qr) \<and> strategy_formula_inner (Attacker_Delayed p Qr) (the (min1_6 (e - E 0 0 0 1 0 0 0 0 0))) \<chi>\<close>
+        using e\<chi>'_spec \<chi>_spec \<Psi>\<chi>_def e_not_low by (auto) (metis option.sel)+
+      moreover have \<open>\<forall>q\<in>Q. spectroscopy_moves (Defender_Stable_Conj p Q Qr) (Attacker_Stable_Clause p q) = Some (\<lambda>e. Option.bind (if \<not> E 0 0 0 1 0 0 0 0 0 \<le> e then None else Some (e - E 0 0 0 1 0 0 0 0 0)) min6_7) \<and>
+           attacker_wins (the (min6_7 (e - E 0 0 0 1 0 0 0 0 0))) (Attacker_Stable_Clause p q) \<and> strategy_formula_conjunct (Attacker_Stable_Clause p q) (e - E 0 0 0 1 0 0 0 0 0) (\<Psi>\<chi> (Some q))\<close>
+        using e\<chi>'_spec \<chi>_spec e'_spec \<Psi>_prop \<Psi>\<chi>_def rQ_def e_not_low apply auto 
+         apply (metis option.sel)
+        sorry
+      ultimately have \<open>strategy_formula_inner (Defender_Stable_Conj p Q Qr) e (StableConj rQ \<Psi>\<chi>)\<close>
+        using stable_conj[of \<Psi>\<chi> p Q Qr e] e\<chi>'_spec \<chi>_spec e'_spec \<Psi>_prop \<Psi>\<chi>_def rQ_def
+        by blast
+      thus \<open>\<exists>\<chi>. strategy_formula_inner (Defender_Stable_Conj p Q Qr) e \<chi> \<and> expr_pr_inner \<chi> \<le> e\<close>
+        using price_bound by blast
     qed
+    thus ?case by simp
+  next
+    case (Attacker_Stable_Clause p q)
+    thus ?case by simp
   qed
 qed
 
@@ -857,7 +865,7 @@ lemma strategy_formulas_distinguish:
         (case g of
        Attacker_Delayed p Q \<Rightarrow> (Q \<Zsurj>S Q) \<longrightarrow> distinguishes_from (Internal \<chi>) p Q
       | Defender_Conj p Q \<Rightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q
-      | Defender_Stable_Conj p Q \<Rightarrow> (\<forall>q. \<not> p \<mapsto> \<tau> q)
+      | Defender_Stable_Conj p Q Qr \<Rightarrow> (\<forall>q. \<not> p \<mapsto> \<tau> q)
           \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p Q
       | Defender_Branch p \<alpha> p' Q Qa \<Rightarrow>(p \<mapsto>a \<alpha> p')
           \<longrightarrow> hml_srbb_inner.distinguishes_from \<chi> p (Q\<union>Qa)
@@ -866,11 +874,12 @@ lemma strategy_formulas_distinguish:
       (strategy_formula_conjunct g e \<psi> \<longrightarrow>
         (case g of
         Attacker_Clause p q \<Rightarrow> hml_srbb_conj.distinguishes \<psi> p q
+      | Attacker_Stable_Clause p q \<Rightarrow> hml_srbb_conj.distinguishes \<psi> p q
       | _ \<Rightarrow> True))\<close>
 proof(induction rule: strategy_formula_strategy_formula_inner_strategy_formula_conjunct.induct)
   case (delay p Q e \<chi>)
   then show ?case
-    by (smt (verit) distinguishes_from_def option.discI silent_reachable.intros(1) silent_reachable_trans spectroscopy_moves.simps(1) spectroscopy_position.simps(50) spectroscopy_position.simps(53))
+    by (smt (verit) distinguishes_from_def option.discI silent_reachable.intros(1) silent_reachable_trans spectroscopy_moves.simps(1) spectroscopy_position.simps)
 next
   case (procrastination p Q e \<chi>)
   from this obtain p' where IH: \<open>spectroscopy_moves (Attacker_Delayed p Q) (Attacker_Delayed p' Q) = Some Some \<and>

--- a/Strategy_Formulas.thy
+++ b/Strategy_Formulas.thy
@@ -732,20 +732,58 @@ next
       ultimately show ?thesis using conj_price_transfer by auto
     qed
   next
-    (* TODO *)
     case (Defender_Stable_Conj p Q Qr)
-    hence cases:
+    have cases:
       \<open>\<forall>g'. spectroscopy_moves (Defender_Stable_Conj p Q Qr) g' \<noteq> None \<longrightarrow>
-       (\<exists>e'. weight (Defender_Stable_Conj p Q) g' e = Some e' \<and> attacker_wins e' g')
-        \<and> ((\<exists>p' q. g' = (Attacker_Clause p' q)) \<or> (\<exists>p' Q'. g' = (Defender_Conj p' Q')))\<close>
-      by (metis (no_types, opaque_lifting)
-            spectroscopy_defender.elims(2,3) spectroscopy_moves.simps(40,42,43,44,55))
-    show ?case
-    proof(cases \<open>Q = {}\<close>)
+       (\<exists>e'. weight (Defender_Stable_Conj p Q Qr) g' e = Some e' \<and> attacker_wins e' g')
+        \<and> ((\<exists>q\<in>Q. g' = Attacker_Stable_Clause p q) \<or> g' = Attacker_Delayed p Qr  \<or> g' = (Defender_Conj p {}))\<close>
+    proof clarify
+      fix g' e'
+      assume case_assm: \<open>spectroscopy_moves (Defender_Stable_Conj p Q Qr) g' = Some e'\<close>
+      hence \<open>\<exists>e'. weight (Defender_Stable_Conj p Q Qr) g' e = Some e' \<and> attacker_wins e' g'\<close>
+        using Defender_Stable_Conj by auto
+      moreover have \<open>(\<exists>q\<in>Q. g' = Attacker_Stable_Clause p q) \<or> g' = Attacker_Delayed p Qr \<or> g' = Defender_Conj p {}\<close>
+        using case_assm Defender_Stable_Conj
+        by (induct g', fastforce, fastforce, fastforce, fastforce, unfold conj_s_revival, smt (verit, ccfv_threshold) not_Some_eq, fastforce, unfold empty_stbl_conj_answer, smt (verit, best) not_None_eq, fastforce)
+      ultimately show
+        \<open>(\<exists>e'. weight (Defender_Stable_Conj p Q Qr) g' e = Some e' \<and> attacker_wins e' g') \<and> ((\<exists>q\<in>Q. g' = Attacker_Stable_Clause p q) \<or> g' = Attacker_Delayed p Qr \<or> g' = Defender_Conj p {})\<close>
+        ..
+    qed
+    have \<open>\<exists>\<chi>. strategy_formula_inner (Defender_Stable_Conj p Q Qr) e \<chi> \<and> expr_pr_inner \<chi> \<le> e\<close>
+    proof
+      obtain e' where e'_spec:
+        \<open>e' = e - (E 0 0 0 1 0 0 0 0 0)\<close>
+        \<open>\<forall>q \<in> Q. weight (Defender_Stable_Conj p Q Qr) (Attacker_Stable_Clause p q) e = Some e'
+          \<and> attacker_wins e' (Attacker_Stable_Clause p q)\<close>
+        using cases local.conj_s_answer
+        by (smt (verit, del_insts) option.distinct(1) option.sel)
+      hence IH: \<open>\<forall>q \<in> Q. \<exists>\<psi>.
+        strategy_formula_conjunct (Attacker_Clause p q) e' \<psi> \<and>
+        expr_pr_conjunct \<psi> \<le> e'\<close>
+        using Defender_Stable_Conj local.conj_s_answer
+        by (smt (verit, best) option.distinct(1) option.inject spectroscopy_position.simps(52))
+      hence \<open>\<exists>\<Phi>. \<forall>q \<in> Q.
+        strategy_formula_conjunct (Attacker_Clause p q) e' (\<Phi> q) \<and>
+        expr_pr_conjunct (\<Phi> q) \<le> e'\<close>
+        by meson
+      then obtain \<Phi> where \<Phi>_prop: \<open>\<forall>q \<in> Q.
+        strategy_formula_conjunct (Attacker_Clause p q) e' (\<Phi> q)
+        \<and> expr_pr_conjunct (\<Phi> q) \<le> e'\<close>
+        by blast
+      have \<open>E 0 0 0 1 0 0 0 0 \<le> e\<close>
+        using e'_spec False by fastforce
+      hence \<open>expr_pr_inner (StableConj Q \<Phi>) \<le> e\<close>
+        using expr_st_conj e'_spec \<Phi>_prop False by metis
+      moreover have \<open>strategy_formula_inner (Defender_Stable_Conj p Q) e (StableConj Q \<Phi>)\<close>
+        using \<Phi>_prop e'_spec stable_conj
+        unfolding e'_spec by fastforce
+      ultimately show ?thesis by auto
+    thus ?case by simp
+    proof(cases \<open>Q = {} \<and> Qr = {}\<close>)
       case True
       then obtain e' where e'_spec:
-        \<open>weight (Defender_Stable_Conj p Q) (Defender_Conj p Q) e = Some e'\<close>
-        \<open>e' = e - (E 0 0 0 1 0 0 0 0)\<close>
+        \<open>weight (Defender_Stable_Conj p Q Qr) (Defender_Conj p Q) e = Some e'\<close>
+        \<open>e' = e - (E 0 0 0 1 0 0 0 0 0)\<close>
         \<open>attacker_wins e' (Defender_Conj p Q)\<close>
         using cases local.empty_stbl_conj_answer
         by (smt (verit, best) option.discI option.sel)

--- a/Strategy_Formulas.thy
+++ b/Strategy_Formulas.thy
@@ -797,8 +797,16 @@ next
         \<open>expr_pr_inner \<chi> \<le> e\<chi>'\<close>
         using Defender_Stable_Conj conj_s_revival spectroscopy_position.simps
         by (smt (verit, best) option.discI option.inject)
-      hence \<chi>e: \<open>expr_pr_conjunct (Pos \<chi>) \<le> the (min1_6 e)\<close> sorry
-      hence \<open>modal_depth_srbb_inner \<chi> \<le> pos_conjuncts e\<close> by simp
+      hence \<chi>e: \<open>expr_pr_conjunct (Pos \<chi>) \<le> the
+          (Option.bind (if \<not> E 0 0 0 1 0 0 0 0 0 \<le> e then None else Some (e - E 0 0 0 1 0 0 0 0 0)) min1_6)\<close>
+        using e\<chi>'_spec(1)
+        by (simp, smt (z3) bind.bind_lunit bind_eq_None_conv energy.sel idiff_0_right
+            min.bounded_iff min_1_6_simps minus_energy_def option.sel)
+      hence \<open>modal_depth_srbb_inner \<chi> \<le> pos_conjuncts e\<close>
+        using \<chi>_spec(2) e\<chi>'_spec(1)
+        by (smt (verit, ccfv_SIG) bind.bind_lunit bind_eq_None_conv energy.sel(1,6)
+            expr_pr_inner.simps idiff_0_right leq_components min_1_6_simps(1) min_def
+            minus_energy_def option.distinct(1) option.sel order_trans)
       hence \<open>\<forall>q\<in>Q. \<exists>\<chi>q. \<Psi> q = Pos \<chi>q \<longrightarrow> modal_depth_srbb_inner \<chi>q \<le> pos_conjuncts e\<close> by blast
       obtain e'' where e''_spec: \<open>subtract_fn  0 0 0 1 0 0 0 0 0 e = Some e''\<close>
         using e_not_low by auto
@@ -807,7 +815,7 @@ next
       define rQ where
         \<open>rQ \<equiv> {None} \<union> Some ` Q\<close>
       have \<open>\<forall>qn \<in> rQ. expr_pr_conjunct (\<Psi>\<chi> qn) \<le> e''\<close>
-        using \<Psi>_prop e'_spec e''_spec \<chi>e e\<chi>'_spec \<chi>_spec leq_components e_not_low
+        using \<Psi>_prop e'_spec e''_spec e\<chi>'_spec \<chi>_spec leq_components e_not_low
         unfolding \<Psi>\<chi>_def rQ_def
         by (simp, smt (z3) bind.bind_lunit energy.sel min.bounded_iff min_1_6_simps min_6_7_simps option.sel)
       moreover have \<open>\<forall>qn \<in> rQ - revival_conjunct_index rQ \<Psi>\<chi>. is_pos (\<Psi>\<chi> qn) \<longrightarrow> modal_depth_srbb_conjunct (\<Psi>\<chi> qn) \<le> pos_conjuncts_sec e''\<close>

--- a/Strategy_Formulas.thy
+++ b/Strategy_Formulas.thy
@@ -63,16 +63,16 @@ where
   conj:
   \<open>strategy_formula_inner (Defender_Conj p Q) e (Conj Q \<Phi>)\<close>
       if \<open>\<forall>q \<in> Q. spectroscopy_moves (Defender_Conj p Q) (Attacker_Clause p q)
-          = (subtract 0 0 1 0 0 0 0 0)
-            \<and> (attacker_wins (e - (E 0 0 1 0 0 0 0 0)) (Attacker_Clause p q))
-            \<and> strategy_formula_conjunct (Attacker_Clause p q) (e - (E 0 0 1 0 0 0 0 0)) (\<Phi> q)\<close> |
+          = (subtract 0 0 1 0 0 0 0 0 0)
+            \<and> (attacker_wins (e - (E 0 0 1 0 0 0 0 0 0)) (Attacker_Clause p q))
+            \<and> strategy_formula_conjunct (Attacker_Clause p q) (e - (E 0 0 1 0 0 0 0 0 0)) (\<Phi> q)\<close> |
 
   imm_conj:
   \<open>strategy_formula (Defender_Conj p Q) e (ImmConj Q \<Phi>)\<close>
       if \<open>\<forall>q \<in> Q. spectroscopy_moves (Defender_Conj p Q) (Attacker_Clause p q)
-          = (subtract 0 0 1 0 0 0 0 0)
-            \<and> (attacker_wins (e - (E 0 0 1 0 0 0 0 0)) (Attacker_Clause p q))
-            \<and> strategy_formula_conjunct (Attacker_Clause p q) (e - (E 0 0 1 0 0 0 0 0)) (\<Phi> q)\<close> |
+          = (subtract 0 0 1 0 0 0 0 0 0)
+            \<and> (attacker_wins (e - (E 0 0 1 0 0 0 0 0 0)) (Attacker_Clause p q))
+            \<and> strategy_formula_conjunct (Attacker_Clause p q) (e - (E 0 0 1 0 0 0 0 0 0)) (\<Phi> q)\<close> |
 
   pos:
   \<open>strategy_formula_conjunct (Attacker_Clause p q) e (Pos \<chi>)\<close>
@@ -81,24 +81,46 @@ where
         \<and> strategy_formula_inner (Attacker_Delayed p Q') (the (min1_6 e)) \<chi>)\<close> |
 
   neg:
-  \<open>strategy_formula_conjunct (Attacker_Clause p q) e (Neg \<chi>)\<close>
-    if \<open>\<exists>P'. (spectroscopy_moves (Attacker_Clause p q) (Attacker_Delayed q P')
-      = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 1) e) min1_7)
-        \<and> attacker_wins (the (min1_7 (e - (E 0 0 0 0 0 0 0 1)))) (Attacker_Delayed q P'))
-        \<and> strategy_formula_inner (Attacker_Delayed q P') (the (min1_7 (e - (E 0 0 0 0 0 0 0 1)))) \<chi>\<close> |
+    \<open>strategy_formula_conjunct (Attacker_Clause p q) e (Neg \<chi>)\<close>
+      if \<open>\<exists>P'.
+          spectroscopy_moves (Attacker_Clause p q) (Attacker_Delayed q P')
+            = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8)
+          \<and> attacker_wins (the (min1_8 (e - (E 0 0 0 0 0 0 0 0 1)))) (Attacker_Delayed q P')
+          \<and> strategy_formula_inner (Attacker_Delayed q P') (the (min1_8 (e - (E 0 0 0 0 0 0 0 0 1)))) \<chi>\<close> |
 
   stable:
-  \<open>strategy_formula_inner (Attacker_Delayed p Q) e \<chi>\<close>
-    if \<open>(\<exists>Q'. spectroscopy_moves (Attacker_Delayed p Q) (Defender_Stable_Conj p Q')
-      = (Some Some) \<and> attacker_wins e (Defender_Stable_Conj p Q')
-        \<and> strategy_formula_inner (Defender_Stable_Conj p Q') e \<chi>)\<close> |
+    \<open>strategy_formula_inner (Attacker_Delayed p Q) e \<chi>\<close>
+      if \<open>\<exists>Q' Qr.
+          spectroscopy_moves (Attacker_Delayed p Q) (Defender_Stable_Conj p Q' Qr) = (Some Some)
+          \<and> attacker_wins e (Defender_Stable_Conj p Q' Qr)
+          \<and> strategy_formula_inner (Defender_Stable_Conj p Q' Qr) e \<chi>\<close> |
 
   stable_conj:
-    \<open>strategy_formula_inner (Defender_Stable_Conj p Q) e (StableConj Q \<Phi>)\<close>
-      if \<open>\<forall>q \<in> Q. spectroscopy_moves (Defender_Stable_Conj p Q) (Attacker_Clause p q)
-        = (subtract 0 0 0 1 0 0 0 0)
-          \<and> attacker_wins (e - (E 0 0 0 1 0 0 0 0)) (Attacker_Clause p q)
-          \<and> strategy_formula_conjunct (Attacker_Clause p q) (e - (E 0 0 0 1 0 0 0 0)) (\<Phi> q)\<close> |
+    \<open>strategy_formula_inner (Defender_Stable_Conj p Q Qr) e (StableConj ({None} \<union> (Some ` Q)) \<Psi>)\<close>
+      if
+        \<open>\<exists>\<phi>. (\<Psi> None) = Pos \<phi> 
+          \<and> spectroscopy_moves (Defender_Stable_Conj p Q Qr) (Attacker_Delayed p Qr)
+            = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 1 0 0 0 0 0) e) min1_6)
+          \<and> attacker_wins (the (min1_6 (e - (E 0 0 0 1 0 0 0 0 0)))) (Attacker_Delayed p Qr)
+          \<and> strategy_formula_inner (Attacker_Delayed q P') (the (min1_6 (e - (E 0 0 0 1 0 0 0 0 0)))) \<phi>\<close> 
+        \<open>\<forall>q \<in> Q.
+          spectroscopy_moves (Defender_Stable_Conj p Q Qr) (Attacker_Stable_Clause p q)
+            = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 1 0 0 0 0 0) e) min6_7)
+          \<and> attacker_wins (the (min6_7 (e - (E 0 0 0 1 0 0 0 0 0)))) (Attacker_Stable_Clause p q)
+          \<and> strategy_formula_conjunct (Attacker_Stable_Clause p q) (e - (E 0 0 0 1 0 0 0 0 0)) (\<Psi> (Some q))\<close> |
+
+  pos_stable:
+    \<open>strategy_formula_conjunct (Attacker_Stable_Clause p q) e (Pos \<chi>)\<close>
+      if \<open>spectroscopy_moves (Attacker_Stable_Clause p q) (Attacker_Delayed p {q}) = Some min1_7
+        \<and> attacker_wins (the (min1_7 e)) (Attacker_Delayed p {q})
+        \<and> strategy_formula_inner (Attacker_Delayed p Q') (the (min1_7 e)) \<chi>\<close> |
+
+  neg_stable:
+    \<open>strategy_formula_conjunct (Attacker_Stable_Clause p q) e (Neg \<chi>)\<close>
+      if \<open>spectroscopy_moves (Attacker_Stable_Clause p q) (Attacker_Delayed q {p})
+            = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8)
+          \<and> attacker_wins (the (min1_8 (e - (E 0 0 0 0 0 0 0 0 1)))) (Attacker_Delayed q {p})
+          \<and> strategy_formula_inner (Attacker_Delayed q P') (the (min1_8 (e - (E 0 0 0 0 0 0 0 0 1)))) \<chi>\<close> |
 
   branch:
   \<open>strategy_formula_inner (Attacker_Delayed p Q) e \<chi>\<close>
@@ -109,16 +131,16 @@ where
   branch_conj:
   \<open>strategy_formula_inner (Defender_Branch p \<alpha> p' Q Q\<alpha>) e (BranchConj \<alpha> \<phi> Q \<Phi>)\<close>
     if \<open>\<exists>Q'. spectroscopy_moves (Defender_Branch p \<alpha> p' Q Q\<alpha>) (Attacker_Branch p' Q')
-          = Some (\<lambda>e. Option.bind ((subtract_fn 0 1 1 0 0 0 0 0) e) min1_6)
+          = Some (\<lambda>e. Option.bind ((subtract_fn 0 1 1 0 0 0 0 0 0) e) min1_6)
             \<and> spectroscopy_moves (Attacker_Branch p' Q') (Attacker_Immediate p' Q')
-            = subtract 1 0 0 0 0 0 0 0
-            \<and> (attacker_wins (the (min1_6 (e - E 0 1 1 0 0 0 0 0)) - (E 1 0 0 0 0 0 0 0))
+            = subtract 1 0 0 0 0 0 0 0 0
+            \<and> (attacker_wins (the (min1_6 (e - E 0 1 1 0 0 0 0 0 0)) - (E 1 0 0 0 0 0 0 0 0))
                   (Attacker_Immediate p' Q'))
-            \<and> strategy_formula (Attacker_Immediate p' Q') (the (min1_6 (e - E 0 1 1 0 0 0 0 0)) - (E 1 0 0 0 0 0 0 0)) \<phi>\<close>
+            \<and> strategy_formula (Attacker_Immediate p' Q') (the (min1_6 (e - E 0 1 1 0 0 0 0 0 0)) - (E 1 0 0 0 0 0 0 0 0)) \<phi>\<close>
         \<open>\<forall>q \<in> Q. spectroscopy_moves (Defender_Branch p \<alpha> p' Q Q\<alpha>) (Attacker_Clause p q)
-          = (subtract 0 1 1 0 0 0 0 0)
-          \<and> attacker_wins (e - (E 0 1 1 0 0 0 0 0)) (Attacker_Clause p q)
-          \<and> strategy_formula_conjunct (Attacker_Clause p q) (e - (E 0 1 1 0 0 0 0 0)) (\<Phi> q)\<close>
+          = (subtract 0 1 1 0 0 0 0 0 0)
+          \<and> attacker_wins (e - (E 0 1 1 0 0 0 0 0 0)) (Attacker_Clause p q)
+          \<and> strategy_formula_conjunct (Attacker_Clause p q) (e - (E 0 1 1 0 0 0 0 0 0)) (\<Phi> q)\<close>
 
 text \<open>To prove \<open>spectroscopy_game_correctness\<close> we need the following implication:
 If \<open>e\<close> is in the winning budget of \<open>Attacker_Immediate p Q\<close>, there is a strategy formula \<open>\<phi>\<close> for
@@ -141,12 +163,15 @@ lemma winning_budget_implies_strategy_formula:
         Attacker_Immediate p Q \<Rightarrow> \<exists>\<phi>. strategy_formula g e \<phi> \<and> expressiveness_price \<phi> \<le> e
       | Attacker_Delayed p Q \<Rightarrow> \<exists>\<chi>. strategy_formula_inner g e \<chi> \<and> expr_pr_inner \<chi> \<le> e
       | Attacker_Clause p q \<Rightarrow> \<exists>\<psi>. strategy_formula_conjunct g e \<psi> \<and> expr_pr_conjunct \<psi> \<le> e
-      | Defender_Conj p Q \<Rightarrow> \<exists>\<chi>. strategy_formula_inner g e \<chi> \<and> expr_pr_inner \<chi> \<le> e
-      | Defender_Stable_Conj p Q \<Rightarrow> \<exists>\<chi>. strategy_formula_inner g e \<chi>  \<and> expr_pr_inner \<chi> \<le> e
+      | Defender_Conj p Q \<Rightarrow> (\<exists>\<chi>. strategy_formula_inner g e \<chi> \<and> expr_pr_inner \<chi> \<le> e)
+                           \<and> (\<exists>\<phi>. strategy_formula g e \<phi> \<and> expressiveness_price \<phi> \<le> e)
+      | Defender_Stable_Conj p Q Qr \<Rightarrow> \<exists>\<chi>. strategy_formula_inner g e \<chi>  \<and> expr_pr_inner \<chi> \<le> e
+      | Attacker_Stable_Clause p q \<Rightarrow> pos_conjuncts_sec  e \<le> pos_conjuncts e \<longrightarrow>
+          (\<exists>\<psi>. strategy_formula_conjunct g e \<psi> \<and> expr_pr_conjunct \<psi> \<le> e)
       | Defender_Branch p \<alpha> p' Q Qa \<Rightarrow> \<exists>\<chi>. strategy_formula_inner g e \<chi> \<and> expr_pr_inner \<chi> \<le> e
       | Attacker_Branch p Q \<Rightarrow>
-            \<exists>\<phi>. strategy_formula (Attacker_Immediate p Q) (e - E 1 0 0 0 0 0 0 0) \<phi>
-              \<and> expressiveness_price \<phi> \<le> e - E 1 0 0 0 0 0 0 0\<close>
+            \<exists>\<phi>. strategy_formula (Attacker_Immediate p Q) (e - E 1 0 0 0 0 0 0 0 0) \<phi>
+              \<and> expressiveness_price \<phi> \<le> e - E 1 0 0 0 0 0 0 0 0\<close>
   using assms
 proof(induction rule: attacker_wins.induct)
   case (Attack g g' e e')
@@ -193,50 +218,47 @@ proof(induction rule: attacker_wins.induct)
     next
       assume \<open>\<exists>p' Q'. g' = Defender_Conj p' Q'\<close>
       then obtain p' Q' where g'_def_conj: \<open>g' = Defender_Conj p' Q'\<close> by blast
-      hence M: \<open>spectroscopy_moves (Attacker_Immediate p Q) (Defender_Conj p' Q') = (subtract 0 0 0 0 1 0 0 0)\<close>
-        using local.f_or_early_conj Attacker_Immediate by presburger
+      hence M: \<open>spectroscopy_moves (Attacker_Immediate p Q) (Defender_Conj p' Q') = (subtract 0 0 0 0 1 0 0 0 0)\<close>
+        using f_or_early_conj Attacker_Immediate by presburger
       hence Qp': \<open>Q\<noteq>{}\<close> \<open>Q = Q'\<close> \<open>p = p'\<close>
-        using Attack.hyps(2) Attacker_Immediate g'_def_conj local.f_or_early_conj by metis+
+        using Attack.hyps(2) Attacker_Immediate g'_def_conj f_or_early_conj by metis+
       from M have \<open>updated (Attacker_Immediate p Q) (Defender_Conj p' Q') e
-                = e - (E 0 0 0 0 1 0 0 0)\<close>
+                = e - (E 0 0 0 0 1 0 0 0 0)\<close>
         using Attack.hyps(3) g'_def_conj Attacker_Immediate
         by (smt (verit) option.distinct(1) option.sel)
-      hence \<open>(attacker_wins (e - (E 0 0 0 0 1 0 0 0)) (Defender_Conj p Q'))\<close>
-         using g'_def_conj Qp' Attacker_Immediate win_a_upwards_closure by force
-      with g'_def_conj have IH_case: \<open>\<exists>\<chi>. strategy_formula_inner g' (updated (Attacker_Immediate p Q) g' e) \<chi> \<and>
-        expr_pr_inner \<chi> \<le> updated (Attacker_Immediate p Q) g' e\<close>
-        using Attacker_Immediate by auto
-      hence \<open>(\<exists>\<chi>. strategy_formula_inner (Defender_Conj p Q) (e - (E 0 0 0 0 1 0 0 0)) \<chi> \<and> expr_pr_inner \<chi> \<le> (e - (E 0 0 0 0 1 0 0 0)))\<close>
-        using \<open>attacker_wins (e - (E 0 0 0 0 1 0 0 0)) (Defender_Conj p Q')\<close> IH_case Qp'
-          \<open>the (weight (Attacker_Immediate p Q) (Defender_Conj p' Q') e) = e - E 0 0 0 0 1 0 0 0\<close> g'_def_conj by auto
-      then obtain \<chi> where S: \<open>(strategy_formula_inner (Defender_Conj p Q) (e - (E 0 0 0 0 1 0 0 0)) \<chi> \<and> expr_pr_inner \<chi> \<le> (e - (E 0 0 0 0 1 0 0 0)))\<close>
+      hence \<open>(attacker_wins (e - (E 0 0 0 0 1 0 0 0 0)) (Defender_Conj p Q'))\<close>
+        using g'_def_conj Qp' Attacker_Immediate win_a_upwards_closure by force
+      hence IH_case: \<open>\<exists>\<phi>. strategy_formula g' (updated (Attacker_Immediate p Q) g' e) \<phi> \<and>
+        expressiveness_price \<phi> \<le> updated (Attacker_Immediate p Q) g' e\<close>
+        using Attacker_Immediate unfolding g'_def_conj Qp' by auto
+      hence \<open>\<exists>\<phi>. strategy_formula (Defender_Conj p Q) (e - (E 0 0 0 0 1 0 0 0 0)) \<phi> \<and> expressiveness_price \<phi> \<le> (e - (E 0 0 0 0 1 0 0 0 0))\<close>
+        using \<open>attacker_wins (e - (E 0 0 0 0 1 0 0 0 0)) (Defender_Conj p Q')\<close> IH_case Qp'
+          \<open>the (weight (Attacker_Immediate p Q) (Defender_Conj p' Q') e) = e - E 0 0 0 0 1 0 0 0 0\<close> g'_def_conj by auto
+      then obtain \<phi> where S:
+        \<open>strategy_formula (Defender_Conj p Q) (e - (E 0 0 0 0 1 0 0 0 0)) \<phi>\<close>
+        \<open>expressiveness_price \<phi> \<le> (e - (E 0 0 0 0 1 0 0 0 0))\<close>
         by blast
-      hence \<open>\<exists>\<psi>. \<chi> = Conj Q \<psi>\<close>
-        using strategy_formula_strategy_formula_inner_strategy_formula_conjunct.conj Qp' g'_def_conj Attacker_Immediate unfolding Qp'
-        by (smt (verit) spectroscopy_moves.simps(60,70) spectroscopy_position.distinct(33) spectroscopy_position.inject(6) strategy_formula_inner.simps)
-      then obtain \<psi> where \<open>\<chi> = Conj Q \<psi>\<close> by auto
-      hence \<open>strategy_formula (Defender_Conj p Q) (e - (E 0 0 0 0 1 0 0 0)) (ImmConj Q \<psi>)\<close>
-        using S strategy_formula_strategy_formula_inner_strategy_formula_conjunct.conj strategy_formula_strategy_formula_inner_strategy_formula_conjunct.imm_conj
-        by (smt (verit) Qp' g'_def_conj hml_srbb_inner.inject(2) Attacker_Immediate spectroscopy_defender.simps(4,6) spectroscopy_moves.simps(60) spectroscopy_moves.simps(70) strategy_formula_inner.cases)
-      hence SI: \<open>strategy_formula (Attacker_Immediate p Q) e (ImmConj Q \<psi>)\<close>
-         using strategy_formula_strategy_formula_inner_strategy_formula_conjunct.delay early_conj Qp'
-         by (metis (no_types, lifting) \<open>attacker_wins (e - E 0 0 0 0 1 0 0 0) (Defender_Conj p Q')\<close> local.f_or_early_conj)
-      have \<open>expr_pr_inner (Conj Q \<psi>) \<le> (e - (E 0 0 0 0 1 0 0 0))\<close> using S \<open>\<chi> = Conj Q \<psi>\<close> by simp
-      hence \<open>expressiveness_price (ImmConj Q \<psi>) \<le> e\<close> using expr_imm_conj Qp'
-        by (smt (verit) M g'_def_conj Attacker_Immediate option.sel option.simps(3))
+      then obtain \<Psi> where \<open>\<phi> = ImmConj Q \<Psi>\<close> by (cases, simp)
+      have \<open>strategy_formula (Defender_Conj p Q) (e - (E 0 0 0 0 1 0 0 0 0)) (ImmConj Q \<Psi>)\<close> 
+        using S unfolding \<open>\<phi>  = ImmConj Q \<Psi>\<close> by blast
+      hence SI: \<open>strategy_formula (Attacker_Immediate p Q) e (ImmConj Q \<Psi>)\<close>
+        using strategy_formula_strategy_formula_inner_strategy_formula_conjunct.delay early_conj Qp'
+        by (metis (no_types, lifting) \<open>attacker_wins (e - E 0 0 0 0 1 0 0 0 0) (Defender_Conj p Q')\<close> f_or_early_conj)
+      hence \<open>expressiveness_price (ImmConj Q \<Psi>) \<le> e\<close> using expr_imm_conj Qp'
+         using S(2) \<open>\<phi> = ImmConj Q \<Psi>\<close> gets_smaller order.trans by blast
       thus ?thesis using SI by auto
     qed
   next
     case (Attacker_Branch p Q)
     hence g'_def: \<open>g' = Attacker_Immediate p Q\<close> using br_acct
-      by (metis (no_types, lifting) spectroscopy_defender.elims(2,3) spectroscopy_moves.simps(17,51,57,61,66,71))
-    hence move: \<open>spectroscopy_moves (Attacker_Branch p Q) g' = subtract 1 0 0 0 0 0 0 0\<close> by simp
+      by (cases g', simp_all) (metis option.discI)+
+    hence move: \<open>spectroscopy_moves (Attacker_Branch p Q) g' = subtract 1 0 0 0 0 0 0 0 0\<close> by simp
     then obtain \<phi> where
       \<open>strategy_formula g' (updated (Attacker_Branch p Q) g' e) \<phi> \<and>
        expressiveness_price \<phi> \<le> updated (Attacker_Branch p Q) g' e\<close>
       using Attacker_Branch g'_def by auto
-    hence \<open>(strategy_formula (Attacker_Immediate p Q) (e - E 1 0 0 0 0 0 0 0) \<phi>)
-        \<and> expressiveness_price \<phi> \<le> e - E 1 0 0 0 0 0 0 0\<close>
+    hence \<open>(strategy_formula (Attacker_Immediate p Q) (e - E 1 0 0 0 0 0 0 0 0) \<phi>)
+        \<and> expressiveness_price \<phi> \<le> e - E 1 0 0 0 0 0 0 0 0\<close>
       using move Attacker_Branch unfolding g'_def
       by (smt (verit, del_insts) option.distinct(1) option.sel)
     then show ?case by auto
@@ -244,7 +266,7 @@ proof(induction rule: attacker_wins.induct)
     case (Attacker_Clause p q)
     hence \<open>(\<exists>p' Q'. g' = (Attacker_Delayed p' Q'))\<close>
       using Attack.hyps spectroscopy_moves.simps
-      by (smt (verit, del_insts) spectroscopy_defender.elims(1))
+      by (smt (verit, del_insts) spectroscopy_defender.elims)
     then obtain p' Q' where
       g'_att_del: \<open>g' = Attacker_Delayed p' Q'\<close> by blast
     show ?case
@@ -261,7 +283,7 @@ proof(induction rule: attacker_wins.induct)
         \<open>strategy_formula_inner (Attacker_Delayed p Q') (the (min1_6 e)) \<chi>\<close>
         \<open>expr_pr_inner \<chi> \<le> the (min1_6 e)\<close>
         using Attacker_Clause Attack True post_win unfolding g'_att_del
-        by (smt (verit) option.sel spectroscopy_position.simps(53))
+        by (smt (verit) option.sel spectroscopy_position.simps)
       hence
         \<open>spectroscopy_moves (Attacker_Clause p q) (Attacker_Delayed p Q') = Some min1_6\<close>
         \<open>attacker_wins (the (min1_6 e)) (Attacker_Delayed p Q')\<close>
@@ -278,18 +300,19 @@ proof(induction rule: attacker_wins.induct)
           using  local.pos_neg_clause Attacker_Clause unfolding g'_att_del
           by presburger+
         hence move: \<open>spectroscopy_moves (Attacker_Clause p q) (Attacker_Delayed p' Q')
-          = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 1) e) min1_7)\<close>
+          = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8)\<close>
           using False by auto
-        hence win: \<open>attacker_wins (the (min1_7 (e - E 0 0 0 0 0 0 0 1))) (Attacker_Delayed p' Q')\<close>
+        hence win: \<open>attacker_wins (the (min1_8 (e - E 0 0 0 0 0 0 0 0 1))) (Attacker_Delayed p' Q')\<close>
           using Attacker_Clause unfolding g'_att_del
           by (smt (verit) bind.bind_lunit bind.bind_lzero option.distinct(1) option.sel)
-        hence \<open>(\<exists>\<phi>. strategy_formula_inner (Attacker_Delayed p' Q') (the (min1_7 (e - E 0 0 0 0 0 0 0 1))) \<phi>
-          \<and> expr_pr_inner \<phi> \<le> the (min1_7 (e - E 0 0 0 0 0 0 0 1)))\<close>
+        hence \<open>(\<exists>\<phi>. strategy_formula_inner (Attacker_Delayed p' Q') (the (min1_8 (e - E 0 0 0 0 0 0 0 0 1))) \<phi>
+          \<and> expr_pr_inner \<phi> \<le> the (min1_8 (e - E 0 0 0 0 0 0 0 0 1)))\<close>
           using Attack Attacker_Clause move unfolding g'_att_del
-          by (smt (verit, del_insts) bind.bind_lunit bind_eq_None_conv option.discI option.sel spectroscopy_position.simps(53))
+          using  bind.bind_lunit bind_eq_None_conv option.discI option.sel
+          by (smt (verit, best) spectroscopy_position.simps(69))
         then obtain \<chi> where \<chi>_spec:
-            \<open>strategy_formula_inner (Attacker_Delayed p' Q') (the (min1_7 (e - E 0 0 0 0 0 0 0 1))) \<chi>\<close>
-            \<open>expr_pr_inner \<chi> \<le> the (min1_7 (e - E 0 0 0 0 0 0 0 1))\<close>
+            \<open>strategy_formula_inner (Attacker_Delayed p' Q') (the (min1_8 (e - E 0 0 0 0 0 0 0 0 1))) \<chi>\<close>
+            \<open>expr_pr_inner \<chi> \<le> the (min1_8 (e - E 0 0 0 0 0 0 0 0 1))\<close>
           by blast
         hence \<open>strategy_formula_conjunct (Attacker_Clause p q) e (Neg \<chi>)\<close>
           using strategy_formula_strategy_formula_inner_strategy_formula_conjunct.delay
@@ -297,15 +320,79 @@ proof(induction rule: attacker_wins.induct)
         thus ?thesis
           using \<chi>_spec Attacker_Clause expr_neg move
           unfolding g'_att_del
-          by (smt (verit, best) bind.bind_lunit bind_eq_None_conv option.distinct(1) option.sel spectroscopy_position.simps(52))
+          using bind.bind_lunit bind_eq_None_conv option.distinct(1) option.sel
+          by (smt (verit, ccfv_SIG) spectroscopy_position.simps(67))
+      qed
+  next
+    case (Attacker_Stable_Clause p q)
+    \<comment> \<open>Mostly analogous to previous case (the negated part is virtually identical)\<close>
+    hence \<open>(\<exists>p' Q'. g' = (Attacker_Delayed p' Q'))\<close>
+      using Attack.hyps spectroscopy_moves.simps
+      by (smt (verit, del_insts) spectroscopy_defender.elims)
+    then obtain p' Q' where
+      g'_att_del: \<open>g' = Attacker_Delayed p' Q'\<close> by blast
+    show ?case
+    proof(cases \<open>p = p'\<close>)
+      case True
+      hence \<open>Q' = {q}\<close>
+        using g'_att_del pos_neg_stable_clause Attacker_Stable_Clause by presburger
+      hence post_win:
+        \<open>(the (spectroscopy_moves (Attacker_Stable_Clause p q) g') e) = min1_7 e\<close>
+         \<open>(attacker_wins (the (min1_7 e)) (Attacker_Delayed p Q'))\<close>
+        using Attacker_Stable_Clause win_a_upwards_closure unfolding True g'_att_del
+        by auto
+      then obtain \<chi> where \<chi>_spec:
+        \<open>strategy_formula_inner (Attacker_Delayed p Q') (the (min1_7 e)) \<chi>\<close>
+        \<open>expr_pr_inner \<chi> \<le> the (min1_7 e)\<close>
+        using Attacker_Stable_Clause Attack True post_win unfolding g'_att_del
+        by (smt (verit) option.sel spectroscopy_position.simps)
+      hence
+        \<open>spectroscopy_moves (Attacker_Stable_Clause p q) (Attacker_Delayed p Q') = Some min1_7\<close>
+        \<open>attacker_wins (the (min1_7 e)) (Attacker_Delayed p Q')\<close>
+        \<open>strategy_formula_inner (Attacker_Delayed p Q') (the (min1_7 e)) \<chi>\<close>
+        using \<open>Q' = {q}\<close> pos_neg_stable_clause post_win by auto
+      hence \<open>strategy_formula_conjunct (Attacker_Stable_Clause p q) e (Pos \<chi>)\<close>
+        using strategy_formula_strategy_formula_inner_strategy_formula_conjunct.delay
+          \<open>Q' = {q}\<close> pos_stable
+        by blast
+      thus ?thesis
+        using \<chi>_spec expr_pos by fastforce
+      next
+        case False
+        hence Qp': \<open>Q' = {p}\<close> \<open>p' = q\<close>
+          using pos_neg_stable_clause Attacker_Stable_Clause unfolding g'_att_del
+          by presburger+
+        hence move: \<open>spectroscopy_moves (Attacker_Stable_Clause p q) (Attacker_Delayed p' Q')
+          = Some (\<lambda>e. Option.bind ((subtract_fn 0 0 0 0 0 0 0 0 1) e) min1_8)\<close>
+          using False by auto
+        hence win: \<open>attacker_wins (the (min1_8 (e - E 0 0 0 0 0 0 0 0 1))) (Attacker_Delayed p' Q')\<close>
+          using Attacker_Stable_Clause unfolding g'_att_del
+          by (smt (verit) bind.bind_lunit bind.bind_lzero option.distinct(1) option.sel)
+        hence \<open>(\<exists>\<phi>. strategy_formula_inner (Attacker_Delayed p' Q') (the (min1_8 (e - E 0 0 0 0 0 0 0 0 1))) \<phi>
+          \<and> expr_pr_inner \<phi> \<le> the (min1_8 (e - E 0 0 0 0 0 0 0 0 1)))\<close>
+          using Attack Attacker_Stable_Clause move unfolding g'_att_del
+          using  bind.bind_lunit bind_eq_None_conv option.discI option.sel
+          by (smt (verit, best) spectroscopy_position.simps(69))
+        then obtain \<chi> where \<chi>_spec:
+            \<open>strategy_formula_inner (Attacker_Delayed p' Q') (the (min1_8 (e - E 0 0 0 0 0 0 0 0 1))) \<chi>\<close>
+            \<open>expr_pr_inner \<chi> \<le> the (min1_8 (e - E 0 0 0 0 0 0 0 0 1))\<close>
+          by blast
+        hence \<open>strategy_formula_conjunct (Attacker_Stable_Clause p q) e (Neg \<chi>)\<close>
+          using strategy_formula_strategy_formula_inner_strategy_formula_conjunct.delay
+            neg_stable Qp' win move by blast
+        thus ?thesis
+          using \<chi>_spec Attacker_Stable_Clause expr_neg move spectroscopy_position.simps
+          unfolding g'_att_del
+          using bind.bind_lunit bind_eq_None_conv option.distinct(1) option.sel
+          by (smt (verit, ccfv_SIG))
       qed
   next
     case (Attacker_Delayed p Q)
     then consider
       (Att_Del) \<open>(\<exists>p Q. g' = Attacker_Delayed p Q)\<close> | (Att_Imm) \<open>(\<exists>p' Q'. g' = (Attacker_Immediate p' Q'))\<close> |
-      (Def_Conj) \<open>(\<exists>p Q. g' = (Defender_Conj p Q))\<close> | (Def_St_Conj) \<open>(\<exists>p Q. g' = (Defender_Stable_Conj p Q))\<close> |
+      (Def_Conj) \<open>(\<exists>p Q. g' = (Defender_Conj p Q))\<close> | (Def_St_Conj) \<open>(\<exists>p Q Qr. g' = (Defender_Stable_Conj p Q Qr))\<close> |
       (Def_Branch) \<open>(\<exists>p' \<alpha> p'' Q' Q\<alpha>. g' = (Defender_Branch p' \<alpha> p'' Q' Q\<alpha>))\<close>
-      by (smt (verit, ccfv_threshold) spectroscopy_defender.elims(1) spectroscopy_moves.simps(27,28))
+      by (cases g', auto)
     then show ?case
     proof (cases)
       case Att_Del
@@ -344,17 +431,17 @@ proof(induction rule: attacker_wins.induct)
       hence \<open>\<exists>a. p \<mapsto>a a p' \<and> Q \<mapsto>aS a Q'\<close> unfolding spectroscopy_moves.simps(3) by presburger
       then obtain \<alpha> where \<alpha>_prop: \<open>p \<mapsto>a \<alpha> p'\<close> \<open>Q \<mapsto>aS \<alpha> Q'\<close> by blast
       moreover then have weight:
-        \<open>spectroscopy_moves (Attacker_Delayed p Q) (Attacker_Immediate p' Q') = subtract 1 0 0 0 0 0 0 0\<close>
+        \<open>spectroscopy_moves (Attacker_Delayed p Q) (Attacker_Immediate p' Q') = subtract 1 0 0 0 0 0 0 0 0\<close>
         by (simp, metis)
-      moreover then have update: \<open>updated (Attacker_Delayed p Q) g' e = e - (E 1 0 0 0 0 0 0 0)\<close>
+      moreover then have update: \<open>updated (Attacker_Delayed p Q) g' e = e - (E 1 0 0 0 0 0 0 0 0)\<close>
         using g'_att_imm Attacker_Delayed
         by (smt (verit, del_insts) option.distinct(1) option.sel)
       moreover then obtain \<chi> where \<chi>_prop:
-        \<open>strategy_formula (Attacker_Immediate p' Q') (e - E 1 0 0 0 0 0 0 0) \<chi>\<close>
-        \<open>expressiveness_price \<chi> \<le> e - E 1 0 0 0 0 0 0 0\<close>
+        \<open>strategy_formula (Attacker_Immediate p' Q') (e - E 1 0 0 0 0 0 0 0 0) \<chi>\<close>
+        \<open>expressiveness_price \<chi> \<le> e - E 1 0 0 0 0 0 0 0 0\<close>
         using Attacker_Delayed g'_att_imm
         by auto
-      moreover have \<open>attacker_wins (e - (E 1 0 0 0 0 0 0 0)) (Attacker_Immediate p' Q')\<close>
+      moreover have \<open>attacker_wins (e - (E 1 0 0 0 0 0 0 0 0)) (Attacker_Immediate p' Q')\<close>
         using attacker_wins.Attack Attack.hyps(4) Attacker_Delayed.prems(3) calculation(4) g'_att_imm
         by force
       ultimately have \<open>strategy_formula_inner (Attacker_Delayed p Q) e (Obs \<alpha> \<chi>)\<close>
@@ -386,21 +473,21 @@ proof(induction rule: attacker_wins.induct)
         by fastforce
     next
       case Def_St_Conj
-      then obtain p' Q' where g'_def: \<open>g' = Defender_Stable_Conj p' Q'\<close> by blast
-      hence pQ': \<open>p = p'\<close> \<open>Q' = { q \<in> Q. (\<nexists>q'. q \<mapsto>\<tau> q')}\<close> \<open>\<nexists>p''. p \<mapsto>\<tau> p''\<close>
+      then obtain p' Q' Qr where g'_def: \<open>g' = Defender_Stable_Conj p' Q' Qr\<close> by blast
+      hence pQ': \<open>p = p'\<close> \<open>Qr \<subseteq> { q \<in> Q. (\<nexists>q'. q \<mapsto>\<tau> q')}\<close> \<open>Q' = { q \<in> Q. (\<nexists>q'. q \<mapsto>\<tau> q')} - Qr\<close> \<open>\<nexists>p''. p \<mapsto>\<tau> p''\<close>
         using local.late_stbl_conj Attacker_Delayed
         by meson+
-      hence \<open>(the (spectroscopy_moves (Attacker_Delayed p Q) (Defender_Stable_Conj p' Q')) e) = Some e\<close>
+      hence \<open>(the (spectroscopy_moves (Attacker_Delayed p Q) (Defender_Stable_Conj p' Q' Qr)) e) = Some e\<close>
         by auto
-      hence \<open>attacker_wins e (Defender_Stable_Conj p' Q')\<close> \<open>updated g g' e = e\<close>
+      hence \<open>attacker_wins e (Defender_Stable_Conj p' Q' Qr)\<close> \<open>updated g g' e = e\<close>
         using Attacker_Delayed Attack unfolding g'_def by force+
       then obtain \<chi> where \<chi>_prop:
-        \<open>strategy_formula_inner (Defender_Stable_Conj p' Q') e \<chi>\<close> \<open>expr_pr_inner \<chi> \<le> e\<close>
+        \<open>strategy_formula_inner (Defender_Stable_Conj p' Q' Qr) e \<chi>\<close> \<open>expr_pr_inner \<chi> \<le> e\<close>
         using Attack g'_def by auto
-      have \<open>spectroscopy_moves (Attacker_Delayed p Q) (Defender_Stable_Conj p' Q') = Some Some
-        \<and> attacker_wins e (Defender_Stable_Conj p' Q')
-        \<and> strategy_formula_inner (Defender_Stable_Conj p' Q') e \<chi>\<close>
-        using Attack \<chi>_prop \<open>attacker_wins e (Defender_Stable_Conj p' Q')\<close> local.late_stbl_conj  pQ'
+      have \<open>spectroscopy_moves (Attacker_Delayed p Q) (Defender_Stable_Conj p' Q' Qr) = Some Some
+        \<and> attacker_wins e (Defender_Stable_Conj p' Q' Qr)
+        \<and> strategy_formula_inner (Defender_Stable_Conj p' Q' Qr) e \<chi>\<close>
+        using Attack \<chi>_prop \<open>attacker_wins e (Defender_Stable_Conj p' Q' Qr)\<close> local.late_stbl_conj  pQ'
         unfolding g'_def
         by force
       thus ?thesis using local.stable[of p Q e \<chi>] pQ' \<chi>_prop by fastforce
@@ -456,58 +543,58 @@ next
   next
     case (Defender_Branch p \<alpha> p' Q Qa)
     hence conjs:
-      \<open>\<forall>q\<in> Q. spectroscopy_moves (Defender_Branch p \<alpha> p' Q Qa) (Attacker_Clause p q) = (subtract 0 1 1 0 0 0 0 0)\<close>
+      \<open>\<forall>q\<in> Q. spectroscopy_moves (Defender_Branch p \<alpha> p' Q Qa) (Attacker_Clause p q) = (subtract 0 1 1 0 0 0 0 0 0)\<close>
       by simp
     obtain e' where e'_spec:
       \<open>\<forall>q\<in>Q. weight (Defender_Branch p \<alpha> p' Q Qa) (Attacker_Clause p q) e = Some e'
         \<and> attacker_wins e' (Attacker_Clause p q)
         \<and> (\<exists>\<psi>. strategy_formula_conjunct (Attacker_Clause p q) e' \<psi> \<and> expr_pr_conjunct \<psi> \<le> e')\<close>
       using conjs Defender_Branch option.distinct(1) option.sel
-      by (smt (z3) spectroscopy_position.simps(52))
-    hence e'_def: \<open>Q \<noteq> {} \<Longrightarrow> e' = e - E 0 1 1 0 0 0 0 0\<close> using conjs
+      by (smt (z3) spectroscopy_position.simps(67))
+    hence e'_def: \<open>Q \<noteq> {} \<Longrightarrow> e' = e - E 0 1 1 0 0 0 0 0 0\<close> using conjs
         by (smt (verit) all_not_in_conv option.distinct(1) option.sel)
     then obtain \<Phi> where \<Phi>_spec:
       \<open>\<forall>q \<in> Q. strategy_formula_conjunct (Attacker_Clause p q) e' (\<Phi> q) \<and> expr_pr_conjunct (\<Phi> q) \<le> e'\<close>
       using e'_spec by metis
 
     have obs: \<open>spectroscopy_moves (Defender_Branch p \<alpha> p' Q Qa) (Attacker_Branch p' (soft_step_set Qa \<alpha>)) =
-      Some (\<lambda>e. Option.bind ((subtract_fn 0 1 1 0 0 0 0 0) e) min1_6)\<close>
+      Some (\<lambda>e. Option.bind ((subtract_fn 0 1 1 0 0 0 0 0 0) e) min1_6)\<close>
       by (simp add: soft_step_set_is_soft_step_set)
     have \<open>\<forall>p Q. (Attacker_Branch p' (soft_step_set Qa \<alpha>)) = (Attacker_Branch p Q) \<longrightarrow> p = p' \<and> Q = soft_step_set Qa \<alpha>\<close> by blast
     with option.discI[OF obs] obtain e'' where
-      \<open>\<exists>\<phi>. strategy_formula (Attacker_Immediate p' (soft_step_set Qa \<alpha>)) (e'' - E 1 0 0 0 0 0 0 0) \<phi>
-        \<and> expressiveness_price \<phi> \<le> e'' - E 1 0 0 0 0 0 0 0\<close>
+      \<open>\<exists>\<phi>. strategy_formula (Attacker_Immediate p' (soft_step_set Qa \<alpha>)) (e'' - E 1 0 0 0 0 0 0 0 0) \<phi>
+        \<and> expressiveness_price \<phi> \<le> e'' - E 1 0 0 0 0 0 0 0 0\<close>
       using Defense.IH option.distinct(1) option.sel
-      by (smt (verit, best) Defender_Branch.prems(2) spectroscopy_position.simps(51))
+      by (smt (z3) Defender_Branch.prems(2) spectroscopy_position.simps(66))
     then obtain \<phi> where
       \<open>strategy_formula (Attacker_Immediate p' (soft_step_set Qa \<alpha>))
-        (updated (Defender_Branch p \<alpha> p' Q Qa) (Attacker_Branch p' (soft_step_set Qa \<alpha>)) e - E 1 0 0 0 0 0 0 0) \<phi>\<close>
-      \<open>expressiveness_price \<phi> \<le> updated (Defender_Branch p \<alpha> p' Q Qa) (Attacker_Branch p' (soft_step_set Qa \<alpha>)) e - E 1 0 0 0 0 0 0 0\<close>
+        (updated (Defender_Branch p \<alpha> p' Q Qa) (Attacker_Branch p' (soft_step_set Qa \<alpha>)) e - E 1 0 0 0 0 0 0 0 0) \<phi>\<close>
+      \<open>expressiveness_price \<phi> \<le> updated (Defender_Branch p \<alpha> p' Q Qa) (Attacker_Branch p' (soft_step_set Qa \<alpha>)) e - E 1 0 0 0 0 0 0 0 0\<close>
       using Defender_Branch.prems(2) option.discI[OF obs]
-      by (smt (verit, best) option.sel spectroscopy_position.simps(51))
+      by (smt (verit, ccfv_threshold) option.sel spectroscopy_position.simps(66))
     hence obs_strat:
-      \<open>strategy_formula (Attacker_Immediate p' (soft_step_set Qa \<alpha>)) (the (min1_6 (e - E 0 1 1 0 0 0 0 0)) - (E 1 0 0 0 0 0 0 0)) \<phi>\<close>
-      \<open>expressiveness_price \<phi> \<le> (the (min1_6 (e - E 0 1 1 0 0 0 0 0)) - (E 1 0 0 0 0 0 0 0))\<close>
+      \<open>strategy_formula (Attacker_Immediate p' (soft_step_set Qa \<alpha>)) (the (min1_6 (e - E 0 1 1 0 0 0 0 0 0)) - (E 1 0 0 0 0 0 0 0 0)) \<phi>\<close>
+      \<open>expressiveness_price \<phi> \<le> (the (min1_6 (e - E 0 1 1 0 0 0 0 0 0)) - (E 1 0 0 0 0 0 0 0 0))\<close>
       by (smt (verit, best) Defender_Branch.prems(2) bind.bind_lunit bind.bind_lzero obs option.distinct(1) option.sel)+
     have  \<open>spectroscopy_moves (Attacker_Branch p' (soft_step_set Qa \<alpha>)) (Attacker_Immediate p' (soft_step_set Qa \<alpha>))
-          = (subtract 1 0 0 0 0 0 0 0)\<close> by simp
+          = (subtract 1 0 0 0 0 0 0 0 0)\<close> by simp
     obtain e'' where win_branch:
-        \<open>Some e'' = min1_6 (e - E 0 1 1 0 0 0 0 0)\<close>
+        \<open>Some e'' = min1_6 (e - E 0 1 1 0 0 0 0 0 0)\<close>
         \<open>attacker_wins e'' (Attacker_Branch p' (soft_step_set Qa \<alpha>))\<close>
       using Defender_Branch
       by (smt (verit, ccfv_threshold) bind.bind_lunit bind_eq_None_conv obs option.discI option.sel)
     then obtain g'' where g''_spec:
       \<open>spectroscopy_moves (Attacker_Branch p' (soft_step_set Qa \<alpha>)) g'' \<noteq> None\<close>
-      \<open>attacker_wins (updated (Attacker_Branch p' (soft_step_set Qa \<alpha>)) g'' (the (min1_6 (e - E 0 1 1 0 0 0 0 0)))) g''\<close>
+      \<open>attacker_wins (updated (Attacker_Branch p' (soft_step_set Qa \<alpha>)) g'' (the (min1_6 (e - E 0 1 1 0 0 0 0 0 0)))) g''\<close>
       using attacker_wins_GaE
       by (metis option.sel spectroscopy_defender.simps(2))
     hence move_immediate:
       \<open>g'' = (Attacker_Immediate p' (soft_step_set Qa \<alpha>))
-      \<and> spectroscopy_moves (Attacker_Branch p' (soft_step_set Qa \<alpha>)) (Attacker_Immediate p' (soft_step_set Qa \<alpha>)) = subtract 1 0 0 0 0 0 0 0\<close>
-      using br_acct
-      by (metis (no_types, lifting) spectroscopy_defender.elims(2,3) spectroscopy_moves.simps(17,51,57,61,66,71))
+      \<and> spectroscopy_moves (Attacker_Branch p' (soft_step_set Qa \<alpha>)) (Attacker_Immediate p' (soft_step_set Qa \<alpha>)) = subtract 1 0 0 0 0 0 0 0 0\<close>
+      using br_acct spectroscopy_defender.elims spectroscopy_moves.simps
+      by (smt (verit))
     then obtain e''' where win_immediate:
-      \<open>Some e''' = subtract_fn 1 0 0 0 0 0 0 0 e''\<close>
+      \<open>Some e''' = subtract_fn 1 0 0 0 0 0 0 0 0 e''\<close>
       \<open>attacker_wins e''' (Attacker_Immediate p' (soft_step_set Qa \<alpha>))\<close>
       using g''_spec win_branch attacker_wins.simps local.br_acct
       by (smt (verit) option.distinct(1) option.sel spectroscopy_defender.elims(1) spectroscopy_moves.simps(17,19,20,51,57,61))

--- a/Strategy_Formulas.thy
+++ b/Strategy_Formulas.thy
@@ -164,7 +164,7 @@ lemma winning_budget_implies_strategy_formula:
       | Attacker_Delayed p Q \<Rightarrow> \<exists>\<chi>. strategy_formula_inner g e \<chi> \<and> expr_pr_inner \<chi> \<le> e
       | Attacker_Clause p q \<Rightarrow> \<exists>\<psi>. strategy_formula_conjunct g e \<psi> \<and> expr_pr_conjunct \<psi> \<le> e
       | Defender_Conj p Q \<Rightarrow> (\<exists>\<chi>. strategy_formula_inner g e \<chi> \<and> expr_pr_inner \<chi> \<le> e)
-                           \<and> (\<exists>\<phi>. strategy_formula g e \<phi> \<and> expressiveness_price \<phi> \<le> e)
+                           \<and> (\<exists>\<phi>. strategy_formula g e \<phi> \<and> expressiveness_price \<phi> - (E 0 0 0 0 1 0 0 0 0) \<le> e)
       | Defender_Stable_Conj p Q Qr \<Rightarrow> \<exists>\<chi>. strategy_formula_inner g e \<chi>  \<and> expr_pr_inner \<chi> \<le> e
       | Attacker_Stable_Clause p q \<Rightarrow> pos_conjuncts_sec  e \<le> pos_conjuncts e \<longrightarrow>
           (\<exists>\<psi>. strategy_formula_conjunct g e \<psi> \<and> expr_pr_conjunct \<psi> \<le> e)
@@ -229,24 +229,31 @@ proof(induction rule: attacker_wins.induct)
       hence \<open>(attacker_wins (e - (E 0 0 0 0 1 0 0 0 0)) (Defender_Conj p Q'))\<close>
         using g'_def_conj Qp' Attacker_Immediate win_a_upwards_closure by force
       hence IH_case: \<open>\<exists>\<phi>. strategy_formula g' (updated (Attacker_Immediate p Q) g' e) \<phi> \<and>
-        expressiveness_price \<phi> \<le> updated (Attacker_Immediate p Q) g' e\<close>
+        expressiveness_price \<phi> - (E 0 0 0 0 1 0 0 0 0) \<le> updated (Attacker_Immediate p Q) g' e\<close>
         using Attacker_Immediate unfolding g'_def_conj Qp' by auto
-      hence \<open>\<exists>\<phi>. strategy_formula (Defender_Conj p Q) (e - (E 0 0 0 0 1 0 0 0 0)) \<phi> \<and> expressiveness_price \<phi> \<le> (e - (E 0 0 0 0 1 0 0 0 0))\<close>
+      hence \<open>\<exists>\<phi>. strategy_formula (Defender_Conj p Q) (e - (E 0 0 0 0 1 0 0 0 0)) \<phi> \<and> expressiveness_price \<phi> - (E 0 0 0 0 1 0 0 0 0) \<le> (e - (E 0 0 0 0 1 0 0 0 0))\<close>
         using \<open>attacker_wins (e - (E 0 0 0 0 1 0 0 0 0)) (Defender_Conj p Q')\<close> IH_case Qp'
           \<open>the (weight (Attacker_Immediate p Q) (Defender_Conj p' Q') e) = e - E 0 0 0 0 1 0 0 0 0\<close> g'_def_conj by auto
       then obtain \<phi> where S:
         \<open>strategy_formula (Defender_Conj p Q) (e - (E 0 0 0 0 1 0 0 0 0)) \<phi>\<close>
-        \<open>expressiveness_price \<phi> \<le> (e - (E 0 0 0 0 1 0 0 0 0))\<close>
+        \<open>expressiveness_price \<phi> - (E 0 0 0 0 1 0 0 0 0) \<le> e - (E 0 0 0 0 1 0 0 0 0)\<close>
         by blast
       then obtain \<Psi> where \<open>\<phi> = ImmConj Q \<Psi>\<close> by (cases, simp)
+      hence non_zero_price:
+          \<open>E 0 0 0 0 1 0 0 0 0 \<le> expressiveness_price \<phi>\<close>
+          \<open>E 0 0 0 0 1 0 0 0 0 \<le> e\<close> using \<open>weight g g' e = Some e'\<close> M
+        using Attacker_Immediate.prems(3) g'_def_conj option.sel Qp'(1) by auto
       have \<open>strategy_formula (Defender_Conj p Q) (e - (E 0 0 0 0 1 0 0 0 0)) (ImmConj Q \<Psi>)\<close> 
         using S unfolding \<open>\<phi>  = ImmConj Q \<Psi>\<close> by blast
       hence SI: \<open>strategy_formula (Attacker_Immediate p Q) e (ImmConj Q \<Psi>)\<close>
         using strategy_formula_strategy_formula_inner_strategy_formula_conjunct.delay early_conj Qp'
         by (metis (no_types, lifting) \<open>attacker_wins (e - E 0 0 0 0 1 0 0 0 0) (Defender_Conj p Q')\<close> f_or_early_conj)
-      hence \<open>expressiveness_price (ImmConj Q \<Psi>) \<le> e\<close> using expr_imm_conj Qp'
-         using S(2) \<open>\<phi> = ImmConj Q \<Psi>\<close> gets_smaller order.trans by blast
-      thus ?thesis using SI by auto
+      hence \<open>expressiveness_price (ImmConj Q \<Psi>) - (E 0 0 0 0 1 0 0 0 0) \<le> e - (E 0 0 0 0 1 0 0 0 0)\<close> using expr_imm_conj Qp'
+        using S(2) \<open>\<phi> = ImmConj Q \<Psi>\<close> gets_smaller order.trans by blast
+      hence \<open>expressiveness_price (ImmConj Q \<Psi>) \<le> e\<close>
+        using non_zero_price energy_subtraction_inequallity
+        using \<open>\<phi> = ImmConj Q \<Psi>\<close> by blast
+      thus ?thesis using SI by fastforce
     qed
   next
     case (Attacker_Branch p Q)
@@ -597,20 +604,19 @@ next
       \<open>Some e''' = subtract_fn 1 0 0 0 0 0 0 0 0 e''\<close>
       \<open>attacker_wins e''' (Attacker_Immediate p' (soft_step_set Qa \<alpha>))\<close>
       using g''_spec win_branch attacker_wins.simps local.br_acct
-      by (smt (verit) option.distinct(1) option.sel spectroscopy_defender.elims(1) spectroscopy_moves.simps(17,19,20,51,57,61))
+      by (smt (verit) option.distinct(1) option.sel spectroscopy_defender.elims(1) spectroscopy_moves.simps)
     hence strat: \<open>strategy_formula_inner (Defender_Branch p \<alpha> p' Q Qa) e (BranchConj \<alpha> \<phi> Q \<Phi>)\<close>
       using branch_conj obs move_immediate obs_strat \<Phi>_spec conjs e'_def e'_spec
       by (smt (verit, best) option.distinct(1) option.sel win_branch(1))
-
-    have \<open>E 1 0 0 0 0 0 0 0 \<le> e''\<close> using win_branch g''_spec
+    have \<open>E 1 0 0 0 0 0 0 0 0 \<le> e''\<close> using win_branch g''_spec
       by (metis option.distinct(1) win_immediate(1))
     hence above_one: \<open>0 < min (modal_depth e) (pos_conjuncts e)\<close>
       using win_immediate win_branch
       by (metis energy.sel(1) energy.sel(6) gr_zeroI idiff_0_right leq_components
             min_1_6_simps(1) minus_energy_def not_one_le_zero option.sel)
-    have \<open>\<forall>q \<in> Q. expr_pr_conjunct (\<Phi> q) \<le> (e - (E 0 1 1 0 0 0 0 0))\<close>
+    have \<open>\<forall>q \<in> Q. expr_pr_conjunct (\<Phi> q) \<le> (e - (E 0 1 1 0 0 0 0 0 0))\<close>
       using \<Phi>_spec e'_def by blast
-    moreover have \<open>expressiveness_price \<phi> \<le> the (min1_6 (e - E 0 1 1 0 0 0 0 0)) - E 1 0 0 0 0 0 0 0\<close>
+    moreover have \<open>expressiveness_price \<phi> \<le> the (min1_6 (e - E 0 1 1 0 0 0 0 0 0)) - E 1 0 0 0 0 0 0 0 0\<close>
       using obs_strat(2) by blast
     moreover hence \<open>modal_depth_srbb \<phi> \<le> min (modal_depth e) (pos_conjuncts e) - 1\<close>
       by simp
@@ -623,18 +629,25 @@ next
     then show ?case using strat by force
   next
     case (Defender_Conj p Q)
-    hence moves:
+    have moves:
       \<open>\<forall>g'. spectroscopy_moves (Defender_Conj p Q) g' \<noteq> None \<longrightarrow> (\<exists>e'. weight (Defender_Conj p Q) g' e = Some e' \<and> attacker_wins e' g')
         \<and> (\<exists>q. g' = (Attacker_Clause p q))\<close>
-      using local.conj_answer
-      by (metis (no_types, lifting) spectroscopy_defender.elims(2,3) spectroscopy_moves.simps(34,35,36,37,38,39))
+    proof (clarify)
+      fix g' y
+      assume \<open>spectroscopy_moves (Defender_Conj p Q) g' = Some y\<close>
+      thus
+        \<open>(\<exists>e'. weight (Defender_Conj p Q) g' e = Some e' \<and> attacker_wins e' g')
+         \<and> (\<exists>q. g' = Attacker_Clause p q)\<close>
+      using local.conj_answer Defender_Conj not_Some_eq
+      by (cases g', fastforce+)
+    qed
     show ?case
     proof (cases \<open>Q = {}\<close>)
       case True
       then obtain \<Phi> where \<open>\<forall>q \<in> Q.
-          spectroscopy_moves (Defender_Conj p Q) (Attacker_Clause p q)  = (subtract 0 0 1 0 0 0 0 0)
-          \<and> (attacker_wins (e - (E 0 0 1 0 0 0 0 0)) (Attacker_Clause p q))
-          \<and> strategy_formula_conjunct (Attacker_Clause p q) (e - (E 0 0 1 0 0 0 0 0)) (\<Phi> q)\<close>
+          spectroscopy_moves (Defender_Conj p Q) (Attacker_Clause p q)  = (subtract 0 0 1 0 0 0 0 0 0)
+          \<and> (attacker_wins (e - (E 0 0 1 0 0 0 0 0 0)) (Attacker_Clause p q))
+          \<and> strategy_formula_conjunct (Attacker_Clause p q) (e - (E 0 0 1 0 0 0 0 0 0)) (\<Phi> q)\<close>
         by (auto simp add: emptyE)
       hence Strat: \<open>strategy_formula_inner (Defender_Conj p Q) e (Conj {} \<Phi>)\<close>
         using \<open>Q = {}\<close> conj by blast
@@ -645,6 +658,7 @@ next
         \<open>st_conj_depth_inner (Conj Q \<Phi>) = Sup ((st_conj_depth_conjunct \<circ> \<Phi>) ` Q)\<close>
         \<open>imm_conj_depth_inner (Conj Q \<Phi>) = Sup ((imm_conj_depth_conjunct \<circ> \<Phi>) ` Q)\<close>
         \<open>max_pos_conj_depth_inner (Conj Q \<Phi>) = Sup ((max_pos_conj_depth_conjunct \<circ> \<Phi>) ` Q)\<close>
+        \<open>max_pos_conj_secondary_depth_inner (Conj Q \<Phi>) = Sup ((max_pos_conj_secondary_depth_conjunct \<circ> \<Phi>) ` Q)\<close>
         \<open>max_neg_conj_depth_inner (Conj Q \<Phi>) = Sup ((max_neg_conj_depth_conjunct \<circ> \<Phi>) ` Q)\<close>
         \<open>neg_depth_inner (Conj Q \<Phi>) = Sup ((neg_depth_conjunct \<circ> \<Phi>) ` Q)\<close>
         using modal_depth_srbb_inner.simps(3) branch_conj_depth_inner.simps st_conj_depth_inner.simps
@@ -658,65 +672,70 @@ next
         \<open>st_conj_depth_inner (Conj Q \<Phi>) = 0\<close>
         \<open>imm_conj_depth_inner (Conj Q \<Phi>) = 0\<close>
         \<open>max_pos_conj_depth_inner (Conj Q \<Phi>) = 0\<close>
+        \<open>max_pos_conj_secondary_depth_inner (Conj Q \<Phi>) = 0\<close>
         \<open>max_neg_conj_depth_inner (Conj Q \<Phi>) = 0\<close>
         \<open>neg_depth_inner (Conj Q \<Phi>) = 0\<close>
         using \<open>Q = {}\<close> by (simp add: bot_enat_def)+
-      hence \<open>expr_pr_inner (Conj Q \<Phi>) = (E 0 0 0 0 0 0 0 0)\<close>
+      hence \<open>expr_pr_inner (Conj Q \<Phi>) = (E 0 0 0 0 0 0 0 0 0)\<close>
         using \<open>Q = {}\<close> by force
       hence price: \<open>expr_pr_inner (Conj Q \<Phi>) \<le> e\<close>
         by auto
-      with Strat price True show ?thesis by auto
+      with Strat price True imm_conj show ?thesis by fastforce
     next
       case False
       hence fa_q: \<open>\<forall>q \<in> Q. \<exists>e'.
-        Some e' = subtract_fn 0 0 1 0 0 0 0 0 e
-        \<and> spectroscopy_moves (Defender_Conj p Q) (Attacker_Clause p q) = (subtract 0 0 1 0 0 0 0 0)
+        Some e' = subtract_fn 0 0 1 0 0 0 0 0 0 e
+        \<and> spectroscopy_moves (Defender_Conj p Q) (Attacker_Clause p q) = (subtract 0 0 1 0 0 0 0 0 0)
         \<and> attacker_wins e' (Attacker_Clause p q)\<close>
         using moves local.conj_answer option.distinct(1)
         by (smt (z3) option.sel)
       have q_ex_e': \<open>\<forall>q \<in> Q.  \<exists>e'.
-           spectroscopy_moves (Defender_Conj p Q) (Attacker_Clause p q) = subtract 0 0 1 0 0 0 0 0
-        \<and> Some e' = subtract_fn 0 0 1 0 0 0 0 0 e
+           spectroscopy_moves (Defender_Conj p Q) (Attacker_Clause p q) = subtract 0 0 1 0 0 0 0 0 0
+        \<and> Some e' = subtract_fn 0 0 1 0 0 0 0 0 0 e
         \<and> attacker_wins e' (Attacker_Clause p q)
         \<and> (\<exists>\<phi>. strategy_formula_conjunct (Attacker_Clause p q) e' \<phi> \<and> expr_pr_conjunct \<phi> \<le> e')\<close>
       proof safe
         fix q
         assume \<open>q \<in> Q\<close>
         then obtain e' where e'_spec:
-          \<open>Some e' = subtract_fn 0 0 1 0 0 0 0 0 e\<close>
-          \<open>spectroscopy_moves (Defender_Conj p Q) (Attacker_Clause p q) = (subtract 0 0 1 0 0 0 0 0)\<close>
+          \<open>Some e' = subtract_fn 0 0 1 0 0 0 0 0 0 e\<close>
+          \<open>spectroscopy_moves (Defender_Conj p Q) (Attacker_Clause p q) = (subtract 0 0 1 0 0 0 0 0 0)\<close>
           \<open>attacker_wins e' (Attacker_Clause p q)\<close>
           using fa_q by blast
         hence \<open>weight (Defender_Conj p Q) (Attacker_Clause p q) e = Some e'\<close>
           by simp
         then have \<open>\<exists>\<psi>. strategy_formula_conjunct (Attacker_Clause p q) e' \<psi> \<and> expr_pr_conjunct \<psi> \<le> e'\<close>
           using Defender_Conj e'_spec
-          by (smt (verit, best) option.distinct(1) option.sel spectroscopy_position.simps(52))
-        thus \<open>\<exists>e'. spectroscopy_moves (Defender_Conj p Q) (Attacker_Clause p q) = (subtract 0 0 1 0 0 0 0 0) \<and>
-              Some e' = subtract_fn 0 0 1 0 0 0 0 0 e \<and>
+          by (smt (verit) option.discI option.sel spectroscopy_position.simps(67))
+        thus \<open>\<exists>e'. spectroscopy_moves (Defender_Conj p Q) (Attacker_Clause p q)
+                  = (subtract 0 0 1 0 0 0 0 0 0) \<and>
+              Some e' = subtract_fn 0 0 1 0 0 0 0 0 0 e \<and>
               attacker_wins e' (Attacker_Clause p q) \<and> (\<exists>\<phi>. strategy_formula_conjunct (Attacker_Clause p q) e' \<phi> \<and> expr_pr_conjunct \<phi> \<le> e')\<close>
           using e'_spec by blast
       qed
       hence \<open>\<exists>\<Phi>. \<forall>q \<in> Q.
-        attacker_wins (e - E 0 0 1 0 0 0 0 0) (Attacker_Clause p q)
-        \<and> (strategy_formula_conjunct (Attacker_Clause p q) (e - E 0 0 1 0 0 0 0 0) (\<Phi> q)
-        \<and> expr_pr_conjunct (\<Phi> q) \<le> (e - E 0 0 1 0 0 0 0 0))\<close>
+        attacker_wins (e - E 0 0 1 0 0 0 0 0 0) (Attacker_Clause p q)
+        \<and> (strategy_formula_conjunct (Attacker_Clause p q) (e - E 0 0 1 0 0 0 0 0 0) (\<Phi> q)
+        \<and> expr_pr_conjunct (\<Phi> q) \<le> (e - E 0 0 1 0 0 0 0 0 0))\<close>
         by (metis (no_types, opaque_lifting) option.distinct(1) option.inject)
       then obtain \<Phi> where IH:
-          \<open>\<forall>q \<in> Q. attacker_wins (e - E 0 0 1 0 0 0 0 0) (Attacker_Clause p q)
-            \<and> (strategy_formula_conjunct (Attacker_Clause p q) (e - E 0 0 1 0 0 0 0 0) (\<Phi> q)
-            \<and> expr_pr_conjunct (\<Phi> q) \<le> (e - E 0 0 1 0 0 0 0 0))\<close> by auto
+          \<open>\<forall>q \<in> Q. attacker_wins (e - E 0 0 1 0 0 0 0 0 0) (Attacker_Clause p q)
+            \<and> (strategy_formula_conjunct (Attacker_Clause p q) (e - E 0 0 1 0 0 0 0 0 0) (\<Phi> q)
+            \<and> expr_pr_conjunct (\<Phi> q) \<le> (e - E 0 0 1 0 0 0 0 0 0))\<close> by auto
       hence \<open>strategy_formula_inner (Defender_Conj p Q) e (Conj Q \<Phi>)\<close>
         by (simp add: conj)
+      moreover have \<open>strategy_formula (Defender_Conj p Q) e (ImmConj Q \<Phi>)\<close>
+        using IH by (simp add: imm_conj)
       moreover have \<open>expr_pr_inner (Conj Q \<Phi>) \<le> e\<close>
         using IH expr_conj \<open>Q \<noteq> {}\<close> q_ex_e'
         by (metis (no_types, lifting) equals0I option.distinct(1))
-      ultimately show ?thesis by auto
+      ultimately show ?thesis using conj_price_transfer by auto
     qed
   next
-    case (Defender_Stable_Conj p Q)
+    (* TODO *)
+    case (Defender_Stable_Conj p Q Qr)
     hence cases:
-      \<open>\<forall>g'. spectroscopy_moves (Defender_Stable_Conj p Q) g' \<noteq> None \<longrightarrow>
+      \<open>\<forall>g'. spectroscopy_moves (Defender_Stable_Conj p Q Qr) g' \<noteq> None \<longrightarrow>
        (\<exists>e'. weight (Defender_Stable_Conj p Q) g' e = Some e' \<and> attacker_wins e' g')
         \<and> ((\<exists>p' q. g' = (Attacker_Clause p' q)) \<or> (\<exists>p' Q'. g' = (Defender_Conj p' Q')))\<close>
       by (metis (no_types, opaque_lifting)


### PR DESCRIPTION
This branch has been about adding another dimension to include stable revivals, failure traces, and ready traces in spectrum and game, along the lines of https://doi.org/10.1007/978-3-031-37706-8_5.

However, I did not manage to finish the proof within the time budget I had assigned before returning to writing my thesis. Therefore, I will finish my thesis writeup without this work, and it's unclear whether I will ever complete it.

I create the PR primarily for future reference.